### PR TITLE
Fix for "String contains null byte" error

### DIFF
--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -71,7 +71,7 @@ module CycloneDX
           xml.publisher author unless author.nil?
           xml.name name
           xml.version version.to_s
-          xml.description description unless description.nil?
+          xml.description { xml.cdata description } unless description.nil?
           unless checksum.nil?
             xml.hashes do
               xml.hash_(checksum, alg: CHECKSUM_ALGORITHM)

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -49,7 +49,7 @@ module CycloneDX
           bom = BOMBuilder.new(component: component_from_options(options), pods: pods).bom(version: options[:bom_version] || 1)
           write_bom_to_file(bom: bom, options: options)
         rescue StandardError => e
-          @logger.error e.message
+          @logger.error ([e.message] + e.backtrace).join($/)
           exit 1
         end
       end

--- a/lib/cyclonedx/cocoapods/version.rb
+++ b/lib/cyclonedx/cocoapods/version.rb
@@ -20,7 +20,7 @@
 
 module CycloneDX
   module CocoaPods
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
     DEPENDENCIES = {
       cocoapods: '~> 1.10.1',
       nokogiri: '~> 1.11.2'


### PR DESCRIPTION
The description of the RxSwift pod seems to contain a null byte character, which doesn't seem to be allowed in the XML output (Nokogiri throws an exception). The description is now wrapped in a CDATA section to allow such characters, and to prevent markup-like strings to break the resulting XML.

Fixes #14 