### PR TITLE
Gather external pod info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Added this CHANGELOG.md file. (macblazer)
+- Local pods now use the `file_name` purl qualifier, and have more information pulled from the local .podspec file. (macblazer)
+- Added a small section in the README.md for contributors and how to set up for local development. (macblazer)
+- Gathering more info for local pods, Git based pods, and podspec based pods. (macblazer)
+
+## [0.1.1]
+
+- Initial publication.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ Usage: `cyclonedx-cocoapods` [options]
 % cyclonedx-cocoapods --path /path/to/cocoapods/project --output /path/to/bom.xml --version 6 
 ```
 
+## Contributing
+
+To set up for local development, make a fork of this repo, make a branch on your fork named after the issue or workflow you are improving, checkout your branch, then run `bundle install`.
+
+### Right to Contribute
+
+This project runs the [DCO](https://probot.github.io/apps/dco/) checker to validate that the code author has the right to submit the code they are
+contributing to the project.  Please verify that you do have the right to contribute, then when running `git commit` add the `-s` flag to
+automatically add the proper `Signed-off-by` line to the commit message.
+
+### Pull requests
+
+Before submitting your pull request, please do the following:
+
+- Run `rake spec` and make sure all the tests pass. If you are adding new commands or features, they must include tests. If you are changing functionality, update the tests or add new tests as needed.
+- Add a note to the CHANGELOG describing what you changed.
+- Make your pull request. If it is related to an issue, add a link to the issue in the description.
 
 ## Copyright & License
 Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE] file for the full license.

--- a/cyclonedx-cocoapods.gemspec
+++ b/cyclonedx-cocoapods.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/CycloneDX/cyclonedx-cocoapods.git"
 
   # Specify which files should be added to the gem when it is released.
-  spec.files = Dir["lib/**/*.{rb,json}"] + %w{ exe/cyclonedx-cocoapods README.md LICENSE NOTICE }
+  spec.files = Dir["lib/**/*.{rb,json}"] + %w{ exe/cyclonedx-cocoapods README.md CHANGELOG.md LICENSE NOTICE }
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -42,8 +42,7 @@ module CycloneDX
 
       class LocalPod
         def source_qualifier
-          # TODO: Should we generate a source qualifier for :path dependencies?
-          {}
+          { file_name: @path }
         end
       end
 

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -124,7 +124,7 @@ module CycloneDX
         options[:podfile_path] = project_dir + 'Podfile'
         raise PodfileParsingError, "Missing Podfile in #{project_dir}. Please use the --path option if not running from the CocoaPods project directory." unless File.exist?(options[:podfile_path])
         options[:podfile_lock_path] = project_dir + 'Podfile.lock'
-        raise PodfileParsingError, "Missing Podfile.lock, please run pod install before generating BOM" unless File.exist?(options[:podfile_lock_path])
+        raise PodfileParsingError, "Missing Podfile.lock, please run 'pod install' before generating BOM" unless File.exist?(options[:podfile_lock_path])
         return ::Pod::Podfile.from_file(options[:podfile_path]), ::Pod::Lockfile.from_file(options[:podfile_lock_path])
       end
 

--- a/lib/cyclonedx/cocoapods/pod_attributes.rb
+++ b/lib/cyclonedx/cocoapods/pod_attributes.rb
@@ -45,19 +45,19 @@ module CycloneDX
 
       class GitRepository
         def attributes_for(pod:)
-          ::Pod::Config.new().sandbox.specification(pod.name).attributes_hash
+          ::Pod::Config.instance.sandbox.specification(pod.name).attributes_hash
         end
       end
 
       class LocalPod
         def attributes_for(pod:)
-          ::Pod::Config.new().sandbox.specification(pod.name).attributes_hash
+          ::Pod::Config.instance.sandbox.specification(pod.name).attributes_hash
         end
       end
 
       class Podspec
         def attributes_for(pod:)
-          ::Pod::Config.new().sandbox.specification(pod.name).attributes_hash
+          ::Pod::Config.instance.sandbox.specification(pod.name).attributes_hash
         end
       end
     end

--- a/lib/cyclonedx/cocoapods/pod_attributes.rb
+++ b/lib/cyclonedx/cocoapods/pod_attributes.rb
@@ -45,19 +45,19 @@ module CycloneDX
 
       class GitRepository
         def attributes_for(pod:)
-          {} # TODO: Retrieve attributes from podspec in git repository
+          ::Pod::Config.new().sandbox.specification(pod.name).attributes_hash
         end
       end
 
       class LocalPod
         def attributes_for(pod:)
-          {} # TODO: Retrieve attributes from podspec in local file system
+          ::Pod::Config.new().sandbox.specification(pod.name).attributes_hash
         end
       end
 
       class Podspec
         def attributes_for(pod:)
-          {} # TODO: Retrieve attributes from podspec in specified location
+          ::Pod::Config.new().sandbox.specification(pod.name).attributes_hash
         end
       end
     end

--- a/lib/cyclonedx/cocoapods/source.rb
+++ b/lib/cyclonedx/cocoapods/source.rb
@@ -40,6 +40,8 @@ module CycloneDX
       end
 
       class LocalPod
+        attr_reader :path
+
         def initialize(path:)
           @path = path
         end

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
     end
 
     context 'when not having an author' do
-      it 'shouldn''t generate a component author' do
+      it 'shouldn\'t generate a component author' do
         expect(xml.at('/component/author')).to be_nil
         expect(xml.at('/component/publisher')).to be_nil
       end
@@ -80,7 +80,7 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
     end
 
     context 'when not having a description' do
-      it 'shouldn''t generate a component description' do
+      it 'shouldn\'t generate a component description' do
         expect(xml.at('/component/description')).to be_nil
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
     end
 
     context 'when not having a homepage' do
-      it 'shouldn''t generate an external references list' do
+      it 'shouldn\'t generate an external references list' do
         expect(xml.at('/component/externalReferences')).to be_nil
       end
     end

--- a/spec/cyclonedx/cocoapods/pod_spec.rb
+++ b/spec/cyclonedx/cocoapods/pod_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
 
           context 'from local disk' do
             let(:source) { CycloneDX::CocoaPods::Source::LocalPod.new(path: '~/Documents/AFNetworking') }
-            let(:expected_purls) { base_purls }
+            let(:expected_purls) { base_purls.map { |purl| purl.insert(purl.index('#') || -1, "?file_name=#{CGI.escape(source.path)}" ) } }
             it_behaves_like "pod_with_checksum"
           end
 

--- a/spec/cyclonedx/cocoapods/source_spec.rb
+++ b/spec/cyclonedx/cocoapods/source_spec.rb
@@ -87,8 +87,7 @@ RSpec.describe CycloneDX::CocoaPods::Source::LocalPod do
     let(:path) { '~/Documents/AFNetworking' }
 
     it 'should generate a proper source qualifier' do
-      # TODO: Should we generate a source qualifier for :path dependencies?
-      expect(described_class.new(path: path).source_qualifier).to eq({})
+      expect(described_class.new(path: path).source_qualifier).to eq({ file_name: "#{path}"})
     end
   end
 end


### PR DESCRIPTION
Fixes #11
Fixes #12 
Fixes #13 

Reading all of the information from the installed local copy of the external pod thanks to the CocoaPods project code. Writing the information to the bom did not have to change since it is in the same format as standard repository based pods.


I added the `file_name` purl qualifier for local pods. The reason I did this is that the [purl specification](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#known-qualifiers-keyvalue-pairs) says

> file_name is an extra file name of a package archive.

Without this extra designation there is no way to tell a local pod from a pod in the default CocoaPods repository list. Here is a made up example of two different CocoaPods purls without the `file_name` qualifier for a local pod:

```ruby
pkg:cocoapods/GzipSwift@4.1.0  # this is available for download from the default CocoaPods listings
pkg:cocoapods/MyLocalPod@0.0.10 # this is a local-only pod; how would you know?
```

Now the same thing with the file_name qualifier:

```ruby
pkg:cocoapods/GzipSwift@4.1.0
pkg:cocoapods/MyLocalPod@0.0.10?file_name=.%2Fincubator%2FMyLocalPod
```

By adding the file_name qualifier it is very easy to understand that the local pod is local and within a folder named ./incubator/MyLocalPod in the local project.