### PR TITLE
Add option to ignore dependencies used for testing

### DIFF
--- a/.licenserc.yml
+++ b/.licenserc.yml
@@ -14,6 +14,7 @@ header:
     - "**/*.json"
     - "**/*.md"
     - "bin/**"
+    - "spec/fixtures/**"
     - "CODEOWNERS"
     - "LICENSE"
     - "NOTICE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+
+- Can now eliminate Podfile targets that include "test" in their name ([Issue #43](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/43)) [@macblazer](https://github.com/macblazer).
+
 ## [1.0.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # CycloneDX CocoaPods (Objective-C/Swift)
 
-The CycloneDX CocoaPods Gem creates a valid CycloneDX software bill-of-material document from all project dependencies. CycloneDX is a lightweight BoM specification that is easily created, human readable, and simple to parse.
+The CycloneDX CocoaPods Gem creates a valid CycloneDX software bill-of-material document from all [CocoaPods](https://cocoapods.org/) project dependencies. CycloneDX is a lightweight BoM specification that is easily created, human readable, and simple to parse.
 
 ## Installation
 
@@ -36,17 +36,29 @@ Building from source requires Ruby 2.4.0 or newer.
 You can use the [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli#convert-command) to convert between multiple BOM formats or specification versions.
 
 ## Usage
-Usage: `cyclonedx-cocoapods` [options]
+```
+Generates a BOM with the given parameters. BOM component metadata is only generated if the component's name, version, and type are provided using the --name, --version, and --type parameters.
+[version <version_number>]
 
-        --[no-]verbose               Run verbosely
-    -p, --path path                  (Optional) Path to CocoaPods project directory, current directory if missing
-    -o, --output bom_file_path       (Optional) Path to output the bom.xml file to
-    -b, --bom-version bom_version    (Optional) Version of the generated BOM, 1 if not provided
-    -g, --group group                (Optional) Group of the component for which the BOM is generated
-    -n, --name name                  (Optional, if specified version and type are also required) Name of the component for which the BOM is generated
-    -v, --version version            (Optional) Version of the component for which the BOM is generated
-    -t, --type type                  (Optional) Type of the component for which the BOM is generated (one of application|framework|library|container|operating-system|device|firmware|file)
+USAGE
+  cyclonedx-cocoapods [options]
+
+OPTIONS
+        --[no-]verbose               Show verbose debugging output
     -h, --help                       Show help message
+
+  BOM Generation
+    -p, --path path                  Path to CocoaPods project directory (default: current directory)
+    -o, --output bom_file_path       Path to output the bom.xml file to (default: "bom.xml")
+    -b, --bom-version bom_version    Version of the generated BOM (default: "1")
+    -x, --exclude-test-targets       Eliminate Podfile targets whose name contains the word "test"
+
+  Component Metadata
+    -n, --name name                  (If specified version and type are also required) Name of the component for which the BOM is generated
+    -v, --version version            Version of the component for which the BOM is generated
+    -t, --type type                  Type of the component for which the BOM is generated (one of application|framework|library|container|operating-system|device|firmware|file)
+    -g, --group group                Group of the component for which the BOM is generated
+```
 
 **Output:** BoM file at specified location, `./bom.xml` if not specified
 

--- a/cyclonedx-cocoapods.gemspec
+++ b/cyclonedx-cocoapods.gemspec
@@ -5,8 +5,8 @@ require_relative "lib/cyclonedx/cocoapods/version"
 Gem::Specification.new do |spec|
   spec.name          = "cyclonedx-cocoapods"
   spec.version       = CycloneDX::CocoaPods::VERSION
-  spec.authors       = ["José González"]
-  spec.email         = ["jose.gonzalez@openinput.com"]
+  spec.authors       = ["José González", "Kyle Hammond"]
+  spec.email         = ["jose.gonzalez@openinput.com", "kyle.hammond@jamf.com"]
 
   spec.summary       = "CycloneDX software bill-of-material (SBOM) generation utility"
   spec.description   = "CycloneDX is a lightweight software bill-of-material (SBOM) specification designed for use in application security contexts and supply chain component analysis. This Gem generates CycloneDX BOMs from CocoaPods projects."

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -59,32 +59,42 @@ module CycloneDX
         component_types = Component::VALID_COMPONENT_TYPES
         OptionParser.new do |options|
           options.banner = <<~BANNER
-            Usage: cyclonedx-cocoapods [options]
-            Generates a BOM with the given parameters. BOM component metadata is only generated if the component's name and version are provided using the --name and --version parameters.
+            Generates a BOM with the given parameters. BOM component metadata is only generated if the component's name, version, and type are provided using the --name, --version, and --type parameters.
+            [version #{CycloneDX::CocoaPods::VERSION}]
+
+            USAGE
+              cyclonedx-cocoapods [options]
+
+            OPTIONS
           BANNER
 
-          options.on('--[no-]verbose', 'Run verbosely') do |v|
+          options.on('--[no-]verbose', 'Show verbose debugging output') do |v|
             parsedOptions[:verbose] = v
           end
-          options.on('-p', '--path path', '(Optional) Path to CocoaPods project directory, current directory if missing') do |path|
+          options.on('-h', '--help', 'Show help message') do
+            puts options
+            exit
+          end
+
+          options.separator("\n  BOM Generation")
+          options.on('-p', '--path path', 'Path to CocoaPods project directory (default: current directory)') do |path|
             parsedOptions[:path] = path
+          end
+          options.on('-o', '--output bom_file_path', 'Path to output the bom.xml file to (default: "bom.xml")') do |bom_file_path|
+            parsedOptions[:bom_file_path] = bom_file_path
+          end
+          options.on('-b', '--bom-version bom_version', Integer, 'Version of the generated BOM (default: "1")') do |version|
+            parsedOptions[:bom_version] = version
           end
           options.on('-x', '--exclude-test-targets', 'Eliminate Podfile targets whose name contains the word "test"') do |exclude|
             parsedOptions[:exclude_test_targets] = exclude
           end
-          options.on('-o', '--output bom_file_path', '(Optional) Path to output the bom.xml file to') do |bom_file_path|
-            parsedOptions[:bom_file_path] = bom_file_path
-          end
-          options.on('-b', '--bom-version bom_version', Integer, '(Optional) Version of the generated BOM, 1 if not provided') do |version|
-            parsedOptions[:bom_version] = version
-          end
-          options.on('-g', '--group group', '(Optional) Group of the component for which the BOM is generated') do |group|
-            parsedOptions[:group] = group
-          end
-          options.on('-n', '--name name', '(Optional, if specified version and type are also required) Name of the component for which the BOM is generated') do |name|
+
+          options.separator("\n  Component Metadata\n")
+          options.on('-n', '--name name', '(If specified version and type are also required) Name of the component for which the BOM is generated') do |name|
             parsedOptions[:name] = name
           end
-          options.on('-v', '--version version', '(Optional) Version of the component for which the BOM is generated') do |version|
+          options.on('-v', '--version version', 'Version of the component for which the BOM is generated') do |version|
             begin
               Gem::Version.new(version)
               parsedOptions[:version] = version
@@ -92,13 +102,12 @@ module CycloneDX
               raise OptionParser::InvalidArgument, e.message
             end
           end
-          options.on('-t', '--type type', "(Optional) Type of the component for which the BOM is generated (one of #{component_types.join('|')})") do |type|
+          options.on('-t', '--type type', "Type of the component for which the BOM is generated (one of #{component_types.join('|')})") do |type|
             raise OptionParser::InvalidArgument, "Invalid value for component's type (#{type}). It must be one of #{component_types.join('|')}" unless component_types.include?(type)
             parsedOptions[:type] = type
           end
-          options.on_tail('-h', '--help', 'Show help message') do
-            puts options
-            exit
+          options.on('-g', '--group group', 'Group of the component for which the BOM is generated') do |group|
+            parsedOptions[:group] = group
           end
         end.parse!
 

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -37,7 +37,7 @@ module CycloneDX
           setup_logger(verbose: options[:verbose])
           @logger.debug "Running cyclonedx-cocoapods with options: #{options}"
 
-          analyzer = PodfileAnalyzer.new(logger: @logger)
+          analyzer = PodfileAnalyzer.new(logger: @logger, exclude_test_targets: options[:exclude_test_targets])
           podfile, lockfile = analyzer.ensure_podfile_and_lock_are_present(options)
           pods = analyzer.parse_pods(podfile, lockfile)
           analyzer.populate_pods_with_additional_info(pods)
@@ -68,6 +68,9 @@ module CycloneDX
           end
           options.on('-p', '--path path', '(Optional) Path to CocoaPods project directory, current directory if missing') do |path|
             parsedOptions[:path] = path
+          end
+          options.on('-x', '--exclude-test-targets', 'Eliminate Podfile targets whose name contains the word "test"') do |exclude|
+            parsedOptions[:exclude_test_targets] = exclude
           end
           options.on('-o', '--output bom_file_path', '(Optional) Path to output the bom.xml file to') do |bom_file_path|
             parsedOptions[:bom_file_path] = bom_file_path

--- a/lib/cyclonedx/cocoapods/podfile_analyzer.rb
+++ b/lib/cyclonedx/cocoapods/podfile_analyzer.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+#
+# This file is part of CycloneDX CocoaPods
+#
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+#
+
+require 'cocoapods'
+require 'logger'
+
+require_relative 'pod'
+require_relative 'pod_attributes'
+require_relative 'source'
+
+module CycloneDX
+  module CocoaPods
+    class PodfileParsingError < StandardError; end
+
+    class PodfileAnalyzer
+      def initialize(logger:)
+        @logger = logger
+      end
+
+      def ensure_podfile_and_lock_are_present(options)
+        project_dir = Pathname.new(options[:path] || Dir.pwd)
+        raise PodfileParsingError, "#{options[:path]} is not a valid directory." unless File.directory?(project_dir)
+        options[:podfile_path] = project_dir + 'Podfile'
+        raise PodfileParsingError, "Missing Podfile in #{project_dir}. Please use the --path option if not running from the CocoaPods project directory." unless File.exist?(options[:podfile_path])
+        options[:podfile_lock_path] = project_dir + 'Podfile.lock'
+        raise PodfileParsingError, "Missing Podfile.lock, please run 'pod install' before generating BOM" unless File.exist?(options[:podfile_lock_path])
+
+        initialize_cocoapods_config(project_dir)
+
+        lockfile = ::Pod::Lockfile.from_file(options[:podfile_lock_path])
+        verify_synced_sandbox(lockfile)
+
+        return ::Pod::Podfile.from_file(options[:podfile_path]), lockfile
+      end
+
+
+      def parse_pods(podfile, lockfile)
+        @logger.debug "Parsing pods from #{podfile.defined_in_file}"
+        return lockfile.pod_names.map do |name|
+          Pod.new(name: name, version: lockfile.version(name), source: source_for_pod(podfile, lockfile, name), checksum: lockfile.checksum(name))
+        end
+      end
+
+
+      def populate_pods_with_additional_info(pods)
+        pods.each do |pod|
+          @logger.debug "Completing information for #{pod.name}"
+          pod.complete_information_from_source
+        end
+        return pods
+      end
+
+
+      private
+
+
+      def initialize_cocoapods_config(project_dir)
+        ::Pod::Config.instance.installation_root = project_dir
+      end
+
+
+      def verify_synced_sandbox(lockfile)
+        manifestFile = ::Pod::Config.instance.sandbox.manifest
+        raise PodfileParsingError, "Missing Manifest.lock, please run 'pod install' before generating BOM" if manifestFile.nil?
+        raise PodfileParsingError, "The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation." unless lockfile == manifestFile
+      end
+
+
+      def cocoapods_repository_source(podfile, lockfile, pod_name)
+        @source_manager ||= create_source_manager(podfile)
+        return Source::CocoaPodsRepository.searchable_source(url: lockfile.spec_repo(pod_name), source_manager: @source_manager)
+      end
+
+
+      def git_source(lockfile, pod_name)
+        checkout_options = lockfile.checkout_options_for_pod_named(pod_name)
+        url = checkout_options[:git]
+        [:tag, :branch, :commit].each do |type|
+          return Source::GitRepository.new(url: url, type: type, label: checkout_options[type]) if checkout_options[type]
+        end
+        return Source::GitRepository.new(url: url)
+      end
+
+
+      def source_for_pod(podfile, lockfile, pod_name)
+        root_name = pod_name.split('/').first
+        return cocoapods_repository_source(podfile, lockfile, root_name) unless lockfile.spec_repo(root_name).nil?
+        return git_source(lockfile, root_name) unless lockfile.checkout_options_for_pod_named(root_name).nil?
+        return Source::LocalPod.new(path: lockfile.to_hash['EXTERNAL SOURCES'][root_name][:path]) if lockfile.to_hash['EXTERNAL SOURCES'][root_name][:path]
+        return Source::Podspec.new(url: lockfile.to_hash['EXTERNAL SOURCES'][root_name][:podspec]) if lockfile.to_hash['EXTERNAL SOURCES'][root_name][:podspec]
+        return nil
+      end
+
+
+      def create_source_manager(podfile)
+        sourceManager = ::Pod::Source::Manager.new(::Pod::Config::instance.repos_dir)
+        @logger.debug "Parsing sources from #{podfile.defined_in_file}"
+        podfile.sources.each do |source|
+          @logger.debug "Ensuring #{source} is available for searches"
+          sourceManager.find_or_create_source_with_url(source)
+        end
+        @logger.debug "Source manager successfully created with all needed sources"
+        return sourceManager
+      end
+    end
+  end
+end

--- a/lib/cyclonedx/cocoapods/version.rb
+++ b/lib/cyclonedx/cocoapods/version.rb
@@ -20,7 +20,7 @@
 
 module CycloneDX
   module CocoaPods
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
     DEPENDENCIES = {
       cocoapods: '~> 1.10.1',
       nokogiri: '~> 1.11.2'

--- a/spec/cyclonedx/cocoapods/podfile_analyzer_spec.rb
+++ b/spec/cyclonedx/cocoapods/podfile_analyzer_spec.rb
@@ -1,0 +1,96 @@
+#
+# This file is part of CycloneDX CocoaPods
+#
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+#
+
+require 'cyclonedx/cocoapods/podfile_analyzer'
+require 'rspec'
+
+RSpec.describe CycloneDX::CocoaPods::PodfileAnalyzer do
+  let(:fixtures) { Pathname.new(File.expand_path('../../../fixtures/', __FILE__)) }
+  let(:simple_pod) { 'SimplePod/Podfile' }
+  let(:tests_pod) { 'TestingPod/Podfile' }
+
+  ::Pod::Config.instance.installation_root = File.expand_path('../../../fixtures/', __FILE__) + '/'
+
+  before(:each) do
+    @log = StringIO.new
+    @logger = Logger.new(@log)
+  end
+
+  context 'parsing pods' do
+    context 'when created with standard parameters' do
+      it 'should find all simple pods' do
+        analyzer = ::CycloneDX::CocoaPods::PodfileAnalyzer.new(logger: @logger)
+
+        simple_pod_file = ::Pod::Podfile.from_file(fixtures + simple_pod)
+        expect(simple_pod_file).not_to be_nil
+        simple_lock_file = ::Pod::Lockfile.from_file(fixtures + (simple_pod + '.lock'))
+        expect(simple_lock_file).not_to be_nil
+
+        included_pods = analyzer.parse_pods(simple_pod_file, simple_lock_file)
+
+        pod_names = included_pods.map(&:name)
+        expect(pod_names).to eq(['Alamofire', 'MSAL', 'MSAL/app-lib'])
+      end
+
+      it 'should find all pods' do
+        analyzer = ::CycloneDX::CocoaPods::PodfileAnalyzer.new(logger: @logger)
+
+        pod_file = ::Pod::Podfile.from_file(fixtures + tests_pod)
+        expect(pod_file).not_to be_nil
+        lock_file = ::Pod::Lockfile.from_file(fixtures + (tests_pod + '.lock'))
+        expect(lock_file).not_to be_nil
+
+        included_pods = analyzer.parse_pods(pod_file, lock_file)
+
+        pod_names = included_pods.map(&:name)
+        expect(pod_names).to eq(['Alamofire', 'MSAL', 'MSAL/app-lib'])
+      end
+    end
+
+    context 'when configured to exclude test pods' do
+      it 'should find all simple pods' do
+        analyzer = ::CycloneDX::CocoaPods::PodfileAnalyzer.new(logger: @logger, exclude_test_targets: true)
+
+        pod_file = ::Pod::Podfile.from_file(fixtures + simple_pod)
+        expect(pod_file).not_to be_nil
+        lock_file = ::Pod::Lockfile.from_file(fixtures + (simple_pod + '.lock'))
+        expect(lock_file).not_to be_nil
+
+        included_pods = analyzer.parse_pods(pod_file, lock_file)
+
+        pod_names = included_pods.map(&:name)
+        expect(pod_names).to eq(['Alamofire', 'MSAL', 'MSAL/app-lib'])
+      end
+
+      it 'should not include testing pods' do
+        analyzer = ::CycloneDX::CocoaPods::PodfileAnalyzer.new(logger: @logger, exclude_test_targets: true)
+
+        pod_file = ::Pod::Podfile.from_file(fixtures + tests_pod)
+        expect(pod_file).not_to be_nil
+        lock_file = ::Pod::Lockfile.from_file(fixtures + (tests_pod + '.lock'))
+        expect(lock_file).not_to be_nil
+
+        included_pods = analyzer.parse_pods(pod_file, lock_file)
+
+        pod_names = included_pods.map(&:name)
+        expect(pod_names).to eq(['Alamofire'])
+      end
+    end
+  end
+end

--- a/spec/fixtures/SimplePod/Podfile
+++ b/spec/fixtures/SimplePod/Podfile
@@ -1,0 +1,7 @@
+project 'SampleProject.xcodeproj'
+platform :osx, '11.0'
+
+target 'SampleProject' do
+  pod 'Alamofire'
+  pod 'MSAL'
+end

--- a/spec/fixtures/SimplePod/Podfile.lock
+++ b/spec/fixtures/SimplePod/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Alamofire (5.6.2)
+  - MSAL (1.2.1):
+    - MSAL/app-lib (= 1.2.1)
+  - MSAL/app-lib (1.2.1)
+
+DEPENDENCIES:
+  - Alamofire
+  - MSAL
+
+SPEC REPOS:
+  trunk:
+    - Alamofire
+    - MSAL
+
+SPEC CHECKSUMS:
+  Alamofire: d368e1ff8a298e6dde360e35a3e68e6c610e7204
+  MSAL: 460571f34a9062c501841d099f8e51fc30557deb
+
+PODFILE CHECKSUM: 16ff6ee7c76cb41d37b9b663e99aabeec75048fd
+
+COCOAPODS: 1.10.1

--- a/spec/fixtures/TestingPod/Podfile
+++ b/spec/fixtures/TestingPod/Podfile
@@ -1,0 +1,10 @@
+project 'SampleProject.xcodeproj'
+platform :osx, '11.0'
+
+target 'SampleProject' do
+  pod 'Alamofire'
+end
+
+target 'SampleProjectTests' do
+  pod 'MSAL'
+end

--- a/spec/fixtures/TestingPod/Podfile.lock
+++ b/spec/fixtures/TestingPod/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Alamofire (5.6.2)
+  - MSAL (1.2.1):
+    - MSAL/app-lib (= 1.2.1)
+  - MSAL/app-lib (1.2.1)
+
+DEPENDENCIES:
+  - Alamofire
+  - MSAL
+
+SPEC REPOS:
+  trunk:
+    - Alamofire
+    - MSAL
+
+SPEC CHECKSUMS:
+  Alamofire: d368e1ff8a298e6dde360e35a3e68e6c610e7204
+  MSAL: 460571f34a9062c501841d099f8e51fc30557deb
+
+PODFILE CHECKSUM: 80a4b35ba91cd678c73505fc72e14e71738bd693
+
+COCOAPODS: 1.10.1


### PR DESCRIPTION
Complex projects can have different dependencies for the test targets vs the production targets.  This allows creating a BOM that includes only non-test targets.  Unit tests were added to verify that this works.

The `-h` help output was starting to get complex so I organized the options to make them easier to understand.

Fixes #43 