### PR TITLE
Improve stability of bom output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,9 @@
 AllCops:
   TargetRubyVersion: 2.4.0
   NewCops: enable
+  Exclude:
+    - 'node_modules/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+    - '.git/**/*'
+    - 'spec/fixtures/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,12 +17,18 @@
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 #
 
+inherit_mode:
+  # Keep the default excluded file paths, and we will exclude more paths
+  merge:
+    - Exclude
+
 AllCops:
   TargetRubyVersion: 2.4.0
   NewCops: enable
+  # Completely ignore test fixture files
   Exclude:
-    - 'node_modules/**/*'
-    - 'tmp/**/*'
-    - 'vendor/**/*'
-    - '.git/**/*'
     - 'spec/fixtures/**/*'
+
+# Allow RSpec files to have long blocks for the tests.
+Metrics/BlockLength:
+  AllowedMethods: ['describe', 'context', 'shared_examples']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0]
+
+### Added
+- Includes dependency relationship information for each of the components. ([Issue #58](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/58)) [@fnxpt](https://github.com/fnxpt).
+
+### Changed
+- Components and dependencies are output in alphabetically sorted order by `purl` to increase reproducability of BOM generation. ([Issue #59](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/59)) [@macblazer](https://github.com/macblazer).
+
 ## [1.1.2]
 
 ### Changed

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -123,9 +123,9 @@ module CycloneDX
       attr_reader :component, :pods, :dependencies
 
       def initialize(pods:, component: nil, dependencies: nil)
-        @pods = pods
+        @pods = pods.sort_by(&:purl)
         @component = component
-        @dependencies = dependencies
+        @dependencies = dependencies&.sort
       end
 
       def bom(version: 1)
@@ -152,7 +152,7 @@ module CycloneDX
       def bom_dependencies(xml, dependencies)
         dependencies&.each do |key, array|
           xml.dependency(ref: key) do
-            array.each do |value|
+            array.sort.each do |value|
               xml.dependency(ref: value)
             end
           end

--- a/lib/cyclonedx/cocoapods/version.rb
+++ b/lib/cyclonedx/cocoapods/version.rb
@@ -21,6 +21,6 @@
 
 module CycloneDX
   module CocoaPods
-    VERSION = '1.1.2'
+    VERSION = '1.2.0'
   end
 end

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -276,6 +276,47 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
         'pkg:cocoapods/Realm@5.5.1' => []
       }
     end
+    # Important: these expected components are sorted alphabetically
+    let(:pod_result) do
+      '<components>
+        <component type="library">
+          <name>Alamofire</name>
+          <version>5.6.2</version>
+          <purl>pkg:cocoapods/Alamofire@5.6.2</purl>
+          <bomRef>pkg:cocoapods/Alamofire@5.6.2</bomRef>
+        </component>
+        <component type="library">
+          <name>FirebaseAnalytics</name>
+          <version>7.10.0</version>
+          <purl>pkg:cocoapods/FirebaseAnalytics@7.10.0</purl>
+          <bomRef>pkg:cocoapods/FirebaseAnalytics@7.10.0</bomRef>
+        </component>
+        <component type="library">
+          <name>MSAL</name>
+          <version>1.2.1</version>
+          <purl>pkg:cocoapods/MSAL@1.2.1</purl>
+          <bomRef>pkg:cocoapods/MSAL@1.2.1</bomRef>
+        </component>
+        <component type="library">
+          <name>MSAL/app-lib</name>
+          <version>1.2.1</version>
+          <purl>pkg:cocoapods/MSAL@1.2.1#app-lib</purl>
+          <bomRef>pkg:cocoapods/MSAL@1.2.1#app-lib</bomRef>
+        </component>
+        <component type="library">
+          <name>Realm</name>
+          <version>5.5.1</version>
+          <purl>pkg:cocoapods/Realm@5.5.1</purl>
+          <bomRef>pkg:cocoapods/Realm@5.5.1</bomRef>
+        </component>
+        <component type="library">
+          <name>RxSwift</name>
+          <version>5.1.2</version>
+          <purl>pkg:cocoapods/RxSwift@5.1.2</purl>
+          <bomRef>pkg:cocoapods/RxSwift@5.1.2</bomRef>
+        </component>
+      </components>'
+    end
 
     shared_examples 'bom_generator' do
       context 'with an incorrect version' do
@@ -362,52 +403,12 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
         end
 
         it 'should properly delegate component node generation to pods' do
-          components_generated_from_bom_builder = xml.at('bom/components')
+          actual = xml.at('bom/components').to_xml
 
-          # Important: these expected components are sorted alphabetically
-          expected_components_string =
-            '<components>
-                <component type="library">
-                  <name>Alamofire</name>
-                  <version>5.6.2</version>
-                  <purl>pkg:cocoapods/Alamofire@5.6.2</purl>
-                  <bomRef>pkg:cocoapods/Alamofire@5.6.2</bomRef>
-                </component>
-                <component type="library">
-                  <name>FirebaseAnalytics</name>
-                  <version>7.10.0</version>
-                  <purl>pkg:cocoapods/FirebaseAnalytics@7.10.0</purl>
-                  <bomRef>pkg:cocoapods/FirebaseAnalytics@7.10.0</bomRef>
-                </component>
-                <component type="library">
-                  <name>MSAL</name>
-                  <version>1.2.1</version>
-                  <purl>pkg:cocoapods/MSAL@1.2.1</purl>
-                  <bomRef>pkg:cocoapods/MSAL@1.2.1</bomRef>
-                </component>
-                <component type="library">
-                  <name>MSAL/app-lib</name>
-                  <version>1.2.1</version>
-                  <purl>pkg:cocoapods/MSAL@1.2.1#app-lib</purl>
-                  <bomRef>pkg:cocoapods/MSAL@1.2.1#app-lib</bomRef>
-                </component>
-                <component type="library">
-                  <name>Realm</name>
-                  <version>5.5.1</version>
-                  <purl>pkg:cocoapods/Realm@5.5.1</purl>
-                  <bomRef>pkg:cocoapods/Realm@5.5.1</bomRef>
-                </component>
-                <component type="library">
-                  <name>RxSwift</name>
-                  <version>5.1.2</version>
-                  <purl>pkg:cocoapods/RxSwift@5.1.2</purl>
-                  <bomRef>pkg:cocoapods/RxSwift@5.1.2</bomRef>
-                </component>
-              </components>'
+          expected = Nokogiri::XML pod_result
+          expected = expected.root.to_xml
 
-          components = Nokogiri::XML expected_components_string
-
-          expect(components_generated_from_bom_builder.to_xml).to be_equivalent_to(components.root.to_xml).respecting_element_order
+          expect(actual).to be_equivalent_to(expected).respecting_element_order
         end
 
         it 'should generate a child dependencies node' do
@@ -415,11 +416,12 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
         end
 
         it 'should properly set dependencies node' do
-          dependencies_generated_from_bom_builder = xml.at('bom/dependencies')
+          actual = xml.at('bom/dependencies').to_xml
 
-          dependencies = Nokogiri::XML dependencies_result
+          expected = Nokogiri::XML dependencies_result
+          expected = expected.root.to_xml
 
-          expect(dependencies_generated_from_bom_builder.to_xml).to be_equivalent_to(dependencies.root.to_xml).respecting_element_order
+          expect(actual).to be_equivalent_to(expected).respecting_element_order
         end
       end
     end

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
   let(:homepage) { 'https://github.com/Alamofire/Alamofire' }
 
   let(:pod) { described_class.new(name: pod_name, version: pod_version, checksum: checksum) }
-  let(:xml) {
+  let(:xml) do
     Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
       pod.add_to_bom(xml)
     end.to_xml)
-  }
+  end
 
   context 'when generating a pod component in a BOM' do
     it 'should generate a root component of type library' do
@@ -71,7 +71,9 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
     end
 
     context 'when having an author' do
-      let(:pod) { described_class.new(name: pod_name, version: pod_version, checksum: checksum).populate(author: author) }
+      let(:pod) do
+        described_class.new(name: pod_name, version: pod_version, checksum: checksum).populate(author: author)
+      end
 
       it 'should generate a correct component author' do
         expect(xml.at('/component/author')).not_to be_nil
@@ -88,7 +90,9 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
     end
 
     context 'when having a description' do
-      let(:pod) { described_class.new(name: pod_name, version: pod_version, checksum: checksum).populate(summary: summary) }
+      let(:pod) do
+        described_class.new(name: pod_name, version: pod_version, checksum: checksum).populate(summary: summary)
+      end
 
       it 'should generate a correct component description' do
         expect(xml.at('/component/description')).not_to be_nil
@@ -99,7 +103,7 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
     context 'when not having a checksum' do
       let(:pod) { described_class.new(name: pod_name, version: pod_version) }
 
-      it 'shouldn''t generate a component hash' do
+      it 'shouldn\'t generate a component hash' do
         expect(xml.at('/component/hashes')).to be_nil
       end
     end
@@ -107,19 +111,22 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
     context 'when having a checksum' do
       it 'should generate a correct component hash' do
         expect(xml.at('/component/hashes/hash')).not_to be_nil
-        expect(xml.at('/component/hashes/hash')['alg']).to eq(described_class::CHECKSUM_ALGORITHM)  # CocoaPods always uses SHA-1
+        # CocoaPods always uses SHA-1
+        expect(xml.at('/component/hashes/hash')['alg']).to eq(described_class::CHECKSUM_ALGORITHM)
         expect(xml.at('/component/hashes/hash').text).to eql(pod.checksum)
       end
     end
 
     context 'when not having a license' do
-      it 'shouldn''t generate a license list' do
+      it 'shouldn\'t generate a license list' do
         expect(xml.at('/component/licenses')).to be_nil
       end
     end
 
     context 'when having a license' do
-      let(:pod) { described_class.new(name: pod_name, version: pod_version, checksum: checksum).populate(license: 'MIT') }
+      let(:pod) do
+        described_class.new(name: pod_name, version: pod_version, checksum: checksum).populate(license: 'MIT')
+      end
 
       it 'should generate a child licenses node' do
         expect(xml.at('/component/licenses')).not_to be_nil
@@ -143,12 +150,15 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
     end
 
     context 'when having a homepage' do
-      let(:pod) { described_class.new(name: pod_name, version: pod_version, checksum: checksum).populate(homepage: homepage) }
+      let(:pod) do
+        described_class.new(name: pod_name, version: pod_version, checksum: checksum).populate(homepage: homepage)
+      end
 
       it 'should properly generate a component external references list' do
         expect(xml.at('/component/externalReferences')).not_to be_nil
         expect(xml.at('/component/externalReferences/reference')).not_to be_nil
-        expect(xml.at('/component/externalReferences/reference')['type']).to eq(described_class::HOMEPAGE_REFERENCE_TYPE)
+        actual = xml.at('/component/externalReferences/reference')['type']
+        expect(actual).to eq(described_class::HOMEPAGE_REFERENCE_TYPE)
         expect(xml.at('/component/externalReferences/reference/url')).not_to be_nil
         expect(xml.at('/component/externalReferences/reference/url').text).to eq(homepage)
       end
@@ -156,16 +166,15 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
   end
 end
 
-
 RSpec.describe CycloneDX::CocoaPods::Pod::License do
   context 'when generating a license in a BOM' do
     context 'for known licenses' do
       let(:license) { described_class.new(identifier: described_class::SPDX_LICENSES.sample) }
-      let(:xml) {
+      let(:xml) do
         Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
           license.add_to_bom(xml)
         end.to_xml)
-      }
+      end
 
       it 'should generate a root license element' do
         expect(xml.at('/license')).not_to be_nil
@@ -183,11 +192,11 @@ RSpec.describe CycloneDX::CocoaPods::Pod::License do
       end
 
       context 'which includes text' do
-        let(:license) {
+        let(:license) do
           license_with_text = described_class.new(identifier: described_class::SPDX_LICENSES.sample)
           license_with_text.text = 'Copyright 2012\nPermission is granted to...'
           license_with_text
-        }
+        end
 
         it 'should create text element' do
           expect(xml.at('/license/text')).not_to be_nil
@@ -196,11 +205,11 @@ RSpec.describe CycloneDX::CocoaPods::Pod::License do
       end
 
       context 'which includes url' do
-        let(:license) {
+        let(:license) do
           license_with_url = described_class.new(identifier: described_class::SPDX_LICENSES.sample)
           license_with_url.url = 'https://opensource.org/licenses/MIT'
           license_with_url
-        }
+        end
 
         it 'should create text element' do
           expect(xml.at('/license/url')).not_to be_nil
@@ -210,7 +219,6 @@ RSpec.describe CycloneDX::CocoaPods::Pod::License do
     end
   end
 end
-
 
 RSpec.describe CycloneDX::CocoaPods::Component do
   context 'when generating a component in a BOM' do
@@ -230,7 +238,9 @@ RSpec.describe CycloneDX::CocoaPods::Component do
 
     context 'without a group' do
       let(:component) { described_class.new(name: 'Application', version: '1.3.5', type: 'application') }
-      let(:xml) { Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml) }
+      let(:xml) do
+        Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
+      end
 
       it_behaves_like 'component'
 
@@ -240,8 +250,12 @@ RSpec.describe CycloneDX::CocoaPods::Component do
     end
 
     context 'with a group' do
-      let(:component) { described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application') }
-      let(:xml) { Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml) }
+      let(:component) do
+        described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application')
+      end
+      let(:xml) do
+        Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
+      end
 
       it_behaves_like 'component'
 
@@ -279,44 +293,44 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
     # Important: these expected components are sorted alphabetically
     let(:pod_result) do
       <<~XML
-      <components>
-        <component type="library">
-          <name>Alamofire</name>
-          <version>5.6.2</version>
-          <purl>pkg:cocoapods/Alamofire@5.6.2</purl>
-          <bomRef>pkg:cocoapods/Alamofire@5.6.2</bomRef>
-        </component>
-        <component type="library">
-          <name>FirebaseAnalytics</name>
-          <version>7.10.0</version>
-          <purl>pkg:cocoapods/FirebaseAnalytics@7.10.0</purl>
-          <bomRef>pkg:cocoapods/FirebaseAnalytics@7.10.0</bomRef>
-        </component>
-        <component type="library">
-          <name>MSAL</name>
-          <version>1.2.1</version>
-          <purl>pkg:cocoapods/MSAL@1.2.1</purl>
-          <bomRef>pkg:cocoapods/MSAL@1.2.1</bomRef>
-        </component>
-        <component type="library">
-          <name>MSAL/app-lib</name>
-          <version>1.2.1</version>
-          <purl>pkg:cocoapods/MSAL@1.2.1#app-lib</purl>
-          <bomRef>pkg:cocoapods/MSAL@1.2.1#app-lib</bomRef>
-        </component>
-        <component type="library">
-          <name>Realm</name>
-          <version>5.5.1</version>
-          <purl>pkg:cocoapods/Realm@5.5.1</purl>
-          <bomRef>pkg:cocoapods/Realm@5.5.1</bomRef>
-        </component>
-        <component type="library">
-          <name>RxSwift</name>
-          <version>5.1.2</version>
-          <purl>pkg:cocoapods/RxSwift@5.1.2</purl>
-          <bomRef>pkg:cocoapods/RxSwift@5.1.2</bomRef>
-        </component>
-      </components>
+        <components>
+          <component type="library">
+            <name>Alamofire</name>
+            <version>5.6.2</version>
+            <purl>pkg:cocoapods/Alamofire@5.6.2</purl>
+            <bomRef>pkg:cocoapods/Alamofire@5.6.2</bomRef>
+          </component>
+          <component type="library">
+            <name>FirebaseAnalytics</name>
+            <version>7.10.0</version>
+            <purl>pkg:cocoapods/FirebaseAnalytics@7.10.0</purl>
+            <bomRef>pkg:cocoapods/FirebaseAnalytics@7.10.0</bomRef>
+          </component>
+          <component type="library">
+            <name>MSAL</name>
+            <version>1.2.1</version>
+            <purl>pkg:cocoapods/MSAL@1.2.1</purl>
+            <bomRef>pkg:cocoapods/MSAL@1.2.1</bomRef>
+          </component>
+          <component type="library">
+            <name>MSAL/app-lib</name>
+            <version>1.2.1</version>
+            <purl>pkg:cocoapods/MSAL@1.2.1#app-lib</purl>
+            <bomRef>pkg:cocoapods/MSAL@1.2.1#app-lib</bomRef>
+          </component>
+          <component type="library">
+            <name>Realm</name>
+            <version>5.5.1</version>
+            <purl>pkg:cocoapods/Realm@5.5.1</purl>
+            <bomRef>pkg:cocoapods/Realm@5.5.1</bomRef>
+          </component>
+          <component type="library">
+            <name>RxSwift</name>
+            <version>5.1.2</version>
+            <purl>pkg:cocoapods/RxSwift@5.1.2</purl>
+            <bomRef>pkg:cocoapods/RxSwift@5.1.2</bomRef>
+          </component>
+        </components>
       XML
     end
 
@@ -345,7 +359,7 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
       end
 
       context 'with a valid version' do
-        let(:version) { Random.rand(100) + 1 }
+        let(:version) { Random.rand(1..100) }
         let(:xml) { Nokogiri::XML(bom_builder.bom(version: version)) }
 
         it 'should be able to use integer-ish versions' do
@@ -354,8 +368,9 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
 
         context 'twice' do
           it 'should generate different serial numbers' do
-            original_serial_number = Nokogiri::XML(bom_builder.bom(version: version)).root['serialNumber']
-            expect(Nokogiri::XML(bom_builder.bom(version: version)).root['serialNumber']).not_to eq(original_serial_number)
+            first_serial_number = Nokogiri::XML(bom_builder.bom(version: version)).root['serialNumber']
+            second_serial_number = Nokogiri::XML(bom_builder.bom(version: version)).root['serialNumber']
+            expect(second_serial_number).not_to eq(first_serial_number)
           end
         end
 
@@ -436,20 +451,22 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
     end
 
     context 'with a component' do
-      let(:component) { CycloneDX::CocoaPods::Component.new(name: 'Application', version: '1.3.5', type: 'application') }
+      let(:component) do
+        CycloneDX::CocoaPods::Component.new(name: 'Application', version: '1.3.5', type: 'application')
+      end
       let(:bom_builder) { described_class.new(component: component, pods: pods, dependencies: dependencies) }
       # Important: these expected dependencies are sorted alphabetically
       let(:dependencies_result) do
         <<~XML
-        <dependencies>
-          <dependency ref="pkg:cocoapods/Alamofire@5.6.2"/>
-          <dependency ref="pkg:cocoapods/FirebaseAnalytics@7.10.0"/>
-          <dependency ref="pkg:cocoapods/MSAL@1.2.1">
-            <dependency ref="pkg:cocoapods/MSAL@1.2.1#app-lib"/>
-          </dependency>
-          <dependency ref="pkg:cocoapods/Realm@5.5.1"/>
-          <dependency ref="pkg:cocoapods/RxSwift@5.1.2"/>
-        </dependencies>
+          <dependencies>
+            <dependency ref="pkg:cocoapods/Alamofire@5.6.2"/>
+            <dependency ref="pkg:cocoapods/FirebaseAnalytics@7.10.0"/>
+            <dependency ref="pkg:cocoapods/MSAL@1.2.1">
+              <dependency ref="pkg:cocoapods/MSAL@1.2.1#app-lib"/>
+            </dependency>
+            <dependency ref="pkg:cocoapods/Realm@5.5.1"/>
+            <dependency ref="pkg:cocoapods/RxSwift@5.1.2"/>
+          </dependencies>
         XML
       end
 

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -278,7 +278,8 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
     end
     # Important: these expected components are sorted alphabetically
     let(:pod_result) do
-      '<components>
+      <<~XML
+      <components>
         <component type="library">
           <name>Alamofire</name>
           <version>5.6.2</version>
@@ -315,7 +316,8 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
           <purl>pkg:cocoapods/RxSwift@5.1.2</purl>
           <bomRef>pkg:cocoapods/RxSwift@5.1.2</bomRef>
         </component>
-      </components>'
+      </components>
+      XML
     end
 
     shared_examples 'bom_generator' do
@@ -438,7 +440,8 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
       let(:bom_builder) { described_class.new(component: component, pods: pods, dependencies: dependencies) }
       # Important: these expected dependencies are sorted alphabetically
       let(:dependencies_result) do
-        '<dependencies>
+        <<~XML
+        <dependencies>
           <dependency ref="pkg:cocoapods/Alamofire@5.6.2"/>
           <dependency ref="pkg:cocoapods/FirebaseAnalytics@7.10.0"/>
           <dependency ref="pkg:cocoapods/MSAL@1.2.1">
@@ -446,7 +449,8 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
           </dependency>
           <dependency ref="pkg:cocoapods/Realm@5.5.1"/>
           <dependency ref="pkg:cocoapods/RxSwift@5.1.2"/>
-        </dependencies>'
+        </dependencies>
+        XML
       end
 
       it_behaves_like 'bom_generator'

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe CycloneDX::CocoaPods::Pod::License do
       context 'which includes text' do
         let(:license) {
           license_with_text = described_class.new(identifier: described_class::SPDX_LICENSES.sample)
-          license_with_text.text = "Copyright 2012\nPermission is granted to..."
+          license_with_text.text = 'Copyright 2012\nPermission is granted to...'
           license_with_text
         }
 
@@ -198,7 +198,7 @@ RSpec.describe CycloneDX::CocoaPods::Pod::License do
       context 'which includes url' do
         let(:license) {
           license_with_url = described_class.new(identifier: described_class::SPDX_LICENSES.sample)
-          license_with_url.url = "https://opensource.org/licenses/MIT"
+          license_with_url.url = 'https://opensource.org/licenses/MIT'
           license_with_url
         }
 
@@ -214,7 +214,7 @@ end
 
 RSpec.describe CycloneDX::CocoaPods::Component do
   context 'when generating a component in a BOM' do
-    shared_examples "component" do
+    shared_examples 'component' do
       it 'should generate a root component element' do
         expect(xml.at('/component')).not_to be_nil
         expect(xml.at('/component')['type']).to eq(component.type)
@@ -232,7 +232,7 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       let(:component) { described_class.new(name: 'Application', version: '1.3.5', type: 'application') }
       let(:xml) { Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml) }
 
-      it_behaves_like "component"
+      it_behaves_like 'component'
 
       it 'should not generate any group element' do
         expect(xml.at('/component/group')).to be_nil
@@ -243,7 +243,7 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       let(:component) { described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application') }
       let(:xml) { Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml) }
 
-      it_behaves_like "component"
+      it_behaves_like 'component'
 
       it 'should generate a proper group element' do
         expect(xml.at('/component/group')).not_to be_nil
@@ -277,7 +277,7 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
       }
     end
 
-    shared_examples "bom_generator" do
+    shared_examples 'bom_generator' do
       context 'with an incorrect version' do
         it 'should raise for non integer versions' do
           expect { bom_builder.bom(version: 'foo') }.to raise_error(ArgumentError)
@@ -414,7 +414,7 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
           expect(xml.at('bom/dependencies')).not_to be_nil
         end
 
-        it 'shoudl properly set dependencies node' do
+        it 'should properly set dependencies node' do
           dependencies_generated_from_bom_builder = xml.at('bom/dependencies')
 
           dependencies = Nokogiri::XML dependencies_result
@@ -428,7 +428,7 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
       let(:bom_builder) { described_class.new(pods: pods) }
       let(:dependencies_result) { '<dependencies/>' }
 
-      it_behaves_like "bom_generator"
+      it_behaves_like 'bom_generator'
     end
 
     context 'with a component' do
@@ -447,7 +447,7 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
         </dependencies>'
       end
 
-      it_behaves_like "bom_generator"
+      it_behaves_like 'bom_generator'
     end
   end
 end


### PR DESCRIPTION
Fixes #59 

Ended up cleaning up 100% of the bom_builder_spec.rb to comply with Rubocop standards (enforced by Codacy check of the PR).