### PR TITLE
Add evidence element for the components

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Check license headers
-      uses: apache/skywalking-eyes@v0.4.0
+      uses: apache/skywalking-eyes@v0.6.0
       with:
         config: .licenserc.yml
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Check license headers
-      uses: apache/skywalking-eyes@v0.6.0
+      uses: apache/skywalking-eyes@v0.4.0
       with:
         config: .licenserc.yml
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,7 @@ Metrics/BlockLength:
 
 # Allow some long methods because breaking them up doesn't help anything.
 Metrics/MethodLength:
-  AllowedMethods: ['parse_options', 'add_to_bom', 'append_all_pod_dependencies']
+  AllowedMethods: ['parse_options', 'add_to_bom', 'append_all_pod_dependencies', 'xml_add_evidence']
 Metrics/AbcSize:
   AllowedMethods: ['parse_options', 'add_to_bom', 'source_for_pod']
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.4.0]
 
 ### Added
-- Added `evidence` element to the component output to indicate that we are doing manifest analisys to generate the bom. ([Issue #69](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/69)) [@macblazer](https://github.com/macblazer).
+- Added `evidence` element to the component output to indicate that we are doing manifest analysis to generate the bom. ([Issue #69](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/69)) [@macblazer](https://github.com/macblazer).
 
 ### Fixed
 - Added top level dependencies when the metadata/component is specified (by using the `--name`, `--version`, and `--type` parameters). ([PR #70](https://github.com/CycloneDX/cyclonedx-cocoapods/pull/70)) [@fnxpt](https://github.com/fnxpt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `evidence` element to the component output to indicate that we are doing manifest analisys to generate the bom. ([Issue #69](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/69)) [@macblazer](https://github.com/macblazer).
 
 ### Fixed
+- Added top level dependencies when the metadata/component is specified (by using the `--name`, `--version`, and `--type` parameters). ([PR #70](https://github.com/CycloneDX/cyclonedx-cocoapods/pull/70)) [@fnxpt](https://github.com/fnxpt)
 - Properly concatenate paths to Podfile and Podfile.lock (with unit tests!). ([Issue #71](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/71)) [@macblazer](https://github.com/macblazer).
 
 ## [1.3.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0]
+
+### Added
+- Added `evidence` element to the component output to indicate that we are doing manifest analisys to generate the bom. ([Issue #69](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/69)) [@macblazer](https://github.com/macblazer).
 
 ### Fixed
 - Properly concatenate paths to Podfile and Podfile.lock (with unit tests!). ([Issue #71](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/71)) [@macblazer](https://github.com/macblazer).

--- a/cyclonedx-cocoapods.gemspec
+++ b/cyclonedx-cocoapods.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'cocoapods', ['>= 1.10.1', '< 2.0']
-  spec.add_runtime_dependency 'nokogiri', ['>= 1.11.2', '< 2.0']
+  spec.add_dependency 'cocoapods', ['>= 1.10.1', '< 2.0']
+  spec.add_dependency 'nokogiri', ['>= 1.11.2', '< 2.0']
 
   spec.add_development_dependency 'equivalent-xml', '~> 0.6.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/example_bom.xml
+++ b/example_bom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1" serialNumber="urn:uuid:7d67e1d1-ebd7-4ae6-8f41-cc045d3542fb">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1" serialNumber="urn:uuid:fb0dad91-a67c-45f9-86d1-00cd0033c0de">
   <metadata>
-    <timestamp>2024-02-08T06:35:59Z</timestamp>
+    <timestamp>2024-10-15T03:43:07Z</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cyclonedx-cocoapods</name>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
       </tool>
     </tools>
-    <component type="application">
+    <component type="application" bom-ref="kizitonwose/PodsUpdater@1.0.3">
       <name>kizitonwose/PodsUpdater</name>
       <version>1.0.3</version>
     </component>
@@ -35,6 +35,19 @@
           <url>http://github.com/raspu/Highlightr</url>
         </reference>
       </externalReferences>
+      <evidence>
+        <identity>
+          <field>purl</field>
+          <confidence>0.6</confidence>
+          <methods>
+            <method>
+              <technique>manifest-analysis</technique>
+              <confidence>0.6</confidence>
+              <value>PodsUpdater/Podfile.lock</value>
+            </method>
+          </methods>
+        </identity>
+      </evidence>
     </component>
     <component type="library" bom-ref="pkg:cocoapods/RxAtomic@4.4.2">
       <author>Krunoslav Zaher &lt;krunoslav.zaher@gmail.com&gt;</author>
@@ -56,6 +69,19 @@
           <url>https://github.com/ReactiveX/RxSwift</url>
         </reference>
       </externalReferences>
+      <evidence>
+        <identity>
+          <field>purl</field>
+          <confidence>0.6</confidence>
+          <methods>
+            <method>
+              <technique>manifest-analysis</technique>
+              <confidence>0.6</confidence>
+              <value>PodsUpdater/Podfile.lock</value>
+            </method>
+          </methods>
+        </identity>
+      </evidence>
     </component>
     <component type="library" bom-ref="pkg:cocoapods/RxCocoa@4.4.2">
       <author>Krunoslav Zaher &lt;krunoslav.zaher@gmail.com&gt;</author>
@@ -79,6 +105,19 @@
           <url>https://github.com/ReactiveX/RxSwift</url>
         </reference>
       </externalReferences>
+      <evidence>
+        <identity>
+          <field>purl</field>
+          <confidence>0.6</confidence>
+          <methods>
+            <method>
+              <technique>manifest-analysis</technique>
+              <confidence>0.6</confidence>
+              <value>PodsUpdater/Podfile.lock</value>
+            </method>
+          </methods>
+        </identity>
+      </evidence>
     </component>
     <component type="library" bom-ref="pkg:cocoapods/RxSwift@4.4.2">
       <author>Krunoslav Zaher &lt;krunoslav.zaher@gmail.com&gt;</author>
@@ -110,9 +149,27 @@ git diff | grep bug | less          #  linux pipes - programs communicate by sen
           <url>https://github.com/ReactiveX/RxSwift</url>
         </reference>
       </externalReferences>
+      <evidence>
+        <identity>
+          <field>purl</field>
+          <confidence>0.6</confidence>
+          <methods>
+            <method>
+              <technique>manifest-analysis</technique>
+              <confidence>0.6</confidence>
+              <value>PodsUpdater/Podfile.lock</value>
+            </method>
+          </methods>
+        </identity>
+      </evidence>
     </component>
   </components>
   <dependencies>
+    <dependency ref="kizitonwose/PodsUpdater@1.0.3">
+      <dependency ref="pkg:cocoapods/Highlightr@2.1.0"/>
+      <dependency ref="pkg:cocoapods/RxCocoa@4.4.2"/>
+      <dependency ref="pkg:cocoapods/RxSwift@4.4.2"/>
+    </dependency>
     <dependency ref="pkg:cocoapods/Highlightr@2.1.0"/>
     <dependency ref="pkg:cocoapods/RxAtomic@4.4.2"/>
     <dependency ref="pkg:cocoapods/RxCocoa@4.4.2">

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -171,6 +171,7 @@ module CycloneDX
       end
     end
 
+    # Turns the internal model data into an XML bom.
     class BOMBuilder
       NAMESPACE = 'http://cyclonedx.org/schema/bom/1.5'
 

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -112,9 +112,11 @@ module CycloneDX
             xml.field 'purl'
             xml.confidence '0.6'
             xml.methods_ do
-              xml.technique 'manifest-analysis'
-              xml.confidence '0.6'
-              xml.value manifest_path
+              xml.method_ do
+                xml.technique 'manifest-analysis'
+                xml.confidence '0.6'
+                xml.value manifest_path
+              end
             end
           end
         end

--- a/lib/cyclonedx/cocoapods/version.rb
+++ b/lib/cyclonedx/cocoapods/version.rb
@@ -21,6 +21,6 @@
 
 module CycloneDX
   module CocoaPods
-    VERSION = '1.3.0'
+    VERSION = '1.4.0'
   end
 end

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe CycloneDX::CocoaPods::Pod do
   let(:pod) { described_class.new(name: pod_name, version: pod_version, checksum: checksum) }
   let(:xml) do
     Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
-      pod.add_to_bom(xml)
+      pod.add_to_bom(xml, 'unused.lock')
     end.to_xml)
   end
 
   let(:shortXML) do
     Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
-      pod.add_to_bom(xml, 7)
+      pod.add_to_bom(xml, 'unused.lock', 7)
     end.to_xml)
   end
 
@@ -330,6 +330,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>Alamofire</name>
             <version>5.6.2</version>
             <purl>pkg:cocoapods/Alamofire@5.6.2</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/FirebaseAnalytics@7.10.0">
             <author>Chewbacca</author>
@@ -337,6 +348,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>FirebaseAnalytics</name>
             <version>7.10.0</version>
             <purl>pkg:cocoapods/FirebaseAnalytics@7.10.0</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/MSAL@1.2.1">
             <author>Chewbacca</author>
@@ -344,6 +366,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>MSAL</name>
             <version>1.2.1</version>
             <purl>pkg:cocoapods/MSAL@1.2.1</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/MSAL@1.2.1#app-lib">
             <author>Chewbacca</author>
@@ -351,6 +384,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>MSAL/app-lib</name>
             <version>1.2.1</version>
             <purl>pkg:cocoapods/MSAL@1.2.1#app-lib</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/Realm@5.5.1">
             <author>Chewbacca</author>
@@ -358,6 +402,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>Realm</name>
             <version>5.5.1</version>
             <purl>pkg:cocoapods/Realm@5.5.1</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/RxSwift@5.1.2">
             <author>Chewbacca</author>
@@ -365,6 +420,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>RxSwift</name>
             <version>5.1.2</version>
             <purl>pkg:cocoapods/RxSwift@5.1.2</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
         </components>
       XML
@@ -379,6 +445,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>Alamofire</name>
             <version>5.6.2</version>
             <purl>pkg:co</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/FirebaseAnalytics@7.10.0">
             <author>Chewba</author>
@@ -386,6 +463,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>FirebaseAnalytics</name>
             <version>7.10.0</version>
             <purl>pkg:co</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/MSAL@1.2.1">
             <author>Chewba</author>
@@ -393,6 +481,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>MSAL</name>
             <version>1.2.1</version>
             <purl>pkg:co</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/MSAL@1.2.1#app-lib">
             <author>Chewba</author>
@@ -400,6 +499,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>MSAL/app-lib</name>
             <version>1.2.1</version>
             <purl>pkg:co</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/Realm@5.5.1">
             <author>Chewba</author>
@@ -407,6 +517,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>Realm</name>
             <version>5.5.1</version>
             <purl>pkg:co</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
           <component type="library" bom-ref="pkg:cocoapods/RxSwift@5.1.2">
             <author>Chewba</author>
@@ -414,6 +535,17 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
             <name>RxSwift</name>
             <version>5.1.2</version>
             <purl>pkg:co</purl>
+            <evidence>
+              <identity>
+                <field>purl</field>
+                <confidence>0.6</confidence>
+                <methods>
+                  <technique>manifest-analysis</technique>
+                  <confidence>0.6</confidence>
+                  <value>sample_manifest.lock</value>
+                </methods>
+              </identity>
+            </evidence>
           </component>
         </components>
       XML
@@ -552,7 +684,7 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
     end
 
     context 'without a component' do
-      let(:bom_builder) { described_class.new(pods: pods) }
+      let(:bom_builder) { described_class.new(pods: pods, manifest_path: 'sample_manifest.lock') }
       let(:dependencies_result) { '<dependencies/>' }
 
       it_behaves_like 'bom_generator'
@@ -562,7 +694,7 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
       let(:component) do
         CycloneDX::CocoaPods::Component.new(name: 'Application', version: '1.3.5', type: 'application')
       end
-      let(:bom_builder) { described_class.new(component: component, pods: pods, dependencies: dependencies) }
+      let(:bom_builder) { described_class.new(component: component, manifest_path: 'sample_manifest.lock', pods: pods, dependencies: dependencies) }
       # Important: these expected dependencies are sorted alphabetically
       let(:dependencies_result) do
         <<~XML

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -335,9 +335,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -353,9 +355,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -371,9 +375,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -389,9 +395,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -407,9 +415,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -425,9 +435,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -450,9 +462,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -468,9 +482,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -486,9 +502,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -504,9 +522,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -522,9 +542,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -540,9 +562,11 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
                 <field>purl</field>
                 <confidence>0.6</confidence>
                 <methods>
-                  <technique>manifest-analysis</technique>
-                  <confidence>0.6</confidence>
-                  <value>sample_manifest.lock</value>
+                  <method>
+                    <technique>manifest-analysis</technique>
+                    <confidence>0.6</confidence>
+                    <value>sample_manifest.lock</value>
+                  </method>
                 </methods>
               </identity>
             </evidence>
@@ -694,7 +718,12 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
       let(:component) do
         CycloneDX::CocoaPods::Component.new(name: 'Application', version: '1.3.5', type: 'application')
       end
-      let(:bom_builder) { described_class.new(component: component, manifest_path: 'sample_manifest.lock', pods: pods, dependencies: dependencies) }
+      let(:bom_builder) do
+        described_class.new(component: component,
+                            manifest_path: 'sample_manifest.lock',
+                            pods: pods,
+                            dependencies: dependencies)
+      end
       # Important: these expected dependencies are sorted alphabetically
       let(:dependencies_result) do
         <<~XML


### PR DESCRIPTION
Added evidence element to the components to indicate that we are doing manifest-analysis.  Also bumping the version number to 1.4.0 in order to do a release.

Tested that the `cyclonedx-cli` tool validates the new output in the example_bom.xml file.

Fixes #69