### PR TITLE
feat: use non-deprecated tools section

### DIFF
--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -240,13 +240,14 @@ module CycloneDX
           component&.add_to_bom(xml)
         end
       end
-
       def bom_tools(xml)
         xml.tools do
-          xml.tool do
-            xml.vendor 'CycloneDX'
-            xml.name_ 'cyclonedx-cocoapods'
-            xml.version VERSION
+          xml.components do
+            xml.component(type: 'application') do
+              xml.group 'CycloneDX'
+              xml.name_ 'cyclonedx-cocoapods'
+              xml.version VERSION
+            end
           end
         end
       end

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -646,9 +646,9 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
           expect(xml.at('bom/metadata/tools')).not_to be_nil
 
           # Only tool should be cyclonedx-cocoapods
-          expect(xml.css('bom/metadata/tools/tool/vendor').text).to eq('CycloneDX')
-          expect(xml.css('bom/metadata/tools/tool/name').text).to eq('cyclonedx-cocoapods')
-          expect(xml.css('bom/metadata/tools/tool/version').text).to eq(CycloneDX::CocoaPods::VERSION)
+          expect(xml.css('bom/metadata/tools/components/component/group').text).to eq('CycloneDX')
+          expect(xml.css('bom/metadata/tools/components/component/name').text).to eq('cyclonedx-cocoapods')
+          expect(xml.css('bom/metadata/tools/components/component/version').text).to eq(CycloneDX::CocoaPods::VERSION)
         end
 
         it 'should generate component metadata when a component is available' do


### PR DESCRIPTION
Since 1.5, the `tools/tool` was replaced with `tools/components/component`. This PR updates the code to use the current tools schema.

See https://cyclonedx.org/schema/bom-1.5.xsd