### PR TITLE
feat: bump schema version to 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Building from source requires Ruby 2.4.0 or newer.
 
 ## Compatibility
 
-*cyclonedx-cocoapods* aims to produce SBOMs according to the latest CycloneDX specification, which currently is [1.5](https://cyclonedx.org/docs/1.5/xml/).
+*cyclonedx-cocoapods* aims to produce SBOMs according to the latest CycloneDX specification, which currently is [1.6](https://cyclonedx.org/docs/1.6/xml/).
 You can use the [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli#convert-command) to convert between multiple BOM formats or specification versions.
 
 ## Usage

--- a/example_bom.xml
+++ b/example_bom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1" serialNumber="urn:uuid:fb0dad91-a67c-45f9-86d1-00cd0033c0de">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1" serialNumber="urn:uuid:fb0dad91-a67c-45f9-86d1-00cd0033c0de">
   <metadata>
     <timestamp>2024-10-15T03:43:07Z</timestamp>
     <tools>

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -173,7 +173,7 @@ module CycloneDX
 
     # Turns the internal model data into an XML bom.
     class BOMBuilder
-      NAMESPACE = 'http://cyclonedx.org/schema/bom/1.5'
+      NAMESPACE = 'http://cyclonedx.org/schema/bom/1.6'
 
       attr_reader :component, :pods, :manifest_path, :dependencies
 

--- a/lib/cyclonedx/cocoapods/pod.rb
+++ b/lib/cyclonedx/cocoapods/pod.rb
@@ -31,15 +31,15 @@ module CycloneDX
       attr_reader :version
       # Anything responding to :source_qualifier
       attr_reader :source
-      # xs:anyURI - https://cyclonedx.org/docs/1.5/xml/#type_externalReference
+      # xs:anyURI - https://cyclonedx.org/docs/1.6/xml/#type_externalReference
       attr_reader :homepage
-      # https://cyclonedx.org/docs/1.5/xml/#type_hashValue (We only use SHA-1 hashes - length == 40)
+      # https://cyclonedx.org/docs/1.6/xml/#type_hashValue (We only use SHA-1 hashes - length == 40)
       attr_reader :checksum
       # xs:normalizedString
       attr_reader :author
       # xs:normalizedString
       attr_reader :description
-      # https://cyclonedx.org/docs/1.5/xml/#type_licenseType
+      # https://cyclonedx.org/docs/1.6/xml/#type_licenseType
       # We don't currently support several licenses or license expressions https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/
       attr_reader :license
 


### PR DESCRIPTION
Produce CycloneDX 1.6. The core structure of 1.6 is the same as 1.5 - the code continues to work as is, generated bom.xml files pass validation, and all of the spec tests pass.