### PR TITLE
feat: add vcs and build-system options to component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,7 @@ Metrics/AbcSize:
 # Configure StringConcatenation to allow Pathname string concatenation
 Style/StringConcatenation:
   Mode: conservative
+
+Metrics/ParameterLists:
+  Max: 6  # Set this to your desired maximum number of parameters
+  CountKeywordArgs: true  # Set to false if you don't want to count keyword arguments

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ OPTIONS
     -v, --version version            Version of the component for which the BOM is generated
     -t, --type type                  Type of the component for which the BOM is generated (one of application|framework|library|container|operating-system|device|firmware|file)
     -g, --group group                Group of the component for which the BOM is generated
+    -s, --source source_url          The Version Control System URL of the component for which the BOM is generated
+    -b, --build build_url            The build URL of the component for which the BOM is generated
 ```
 
 **Output:** BoM file at specified location, `./bom.xml` if not specified

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -167,6 +167,18 @@ module CycloneDX
           xml.group group unless group.nil?
           xml.name_ name
           xml.version version
+
+          if !buildSystem.nil? || !vcs.nil?
+            xml.externalReferences do
+              xml.reference(type: 'build-system') do
+                xml.url buildSystem
+              end if buildSystem
+
+              xml.reference(type: 'vcs') do
+                xml.url vcs
+              end if vcs
+            end
+          end
         end
       end
     end

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -168,15 +168,19 @@ module CycloneDX
           xml.name_ name
           xml.version version
 
-          if !buildSystem.nil? || !vcs.nil?
+          if !build_system.nil? || !vcs.nil?
             xml.externalReferences do
-              xml.reference(type: 'build-system') do
-                xml.url buildSystem
-              end if buildSystem
+              if build_system
+                xml.reference(type: 'build-system') do
+                  xml.url build_system
+                end
+              end
 
-              xml.reference(type: 'vcs') do
-                xml.url vcs
-              end if vcs
+              if vcs
+                xml.reference(type: 'vcs') do
+                  xml.url vcs
+                end
+              end
             end
           end
         end

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -119,7 +119,7 @@ module CycloneDX
             parsed_options[:group] = group
           end
           options.on('-s', '--source source_url',
-                     'Optional: The version control system URL of the component for which the BOM is generated') do |vcs|
+                     'Optional: The version control system URL of the component for the BOM is generated') do |vcs|
             parsed_options[:vcs] = vcs
           end
           options.on('-b', '--build build_url',

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -118,6 +118,12 @@ module CycloneDX
           options.on('-g', '--group group', 'Group of the component for which the BOM is generated') do |group|
             parsed_options[:group] = group
           end
+          options.on('-s', '--source source_url', 'Optional: The version control system URL of the component for which the BOM is generated') do |vcs|
+            parsed_options[:vcs] = vcs
+          end
+          options.on('-b', '--build build_url', 'Optional: The build URL of the component for which the BOM is generated') do |build|
+            parsed_options[:build] = build
+          end
         end.parse!
 
         if !parsed_options[:name].nil? && (parsed_options[:version].nil? || parsed_options[:type].nil?)
@@ -163,7 +169,7 @@ module CycloneDX
         return unless options[:name]
 
         Component.new(group: options[:group], name: options[:name], version: options[:version],
-                      type: options[:type])
+                      type: options[:type], buildSystem: options[:build], vcs: options[:vcs])
       end
 
       def setup_logger(verbose: true)

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -118,10 +118,12 @@ module CycloneDX
           options.on('-g', '--group group', 'Group of the component for which the BOM is generated') do |group|
             parsed_options[:group] = group
           end
-          options.on('-s', '--source source_url', 'Optional: The version control system URL of the component for which the BOM is generated') do |vcs|
+          options.on('-s', '--source source_url',
+                     'Optional: The version control system URL of the component for which the BOM is generated') do |vcs|
             parsed_options[:vcs] = vcs
           end
-          options.on('-b', '--build build_url', 'Optional: The build URL of the component for which the BOM is generated') do |build|
+          options.on('-b', '--build build_url',
+                     'Optional: The build URL of the component for which the BOM is generated') do |build|
             parsed_options[:build] = build
           end
         end.parse!
@@ -169,7 +171,7 @@ module CycloneDX
         return unless options[:name]
 
         Component.new(group: options[:group], name: options[:name], version: options[:version],
-                      type: options[:type], buildSystem: options[:build], vcs: options[:vcs])
+                      type: options[:type], build_system: options[:build], vcs: options[:vcs])
       end
 
       def setup_logger(verbose: true)

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -74,12 +74,12 @@ module CycloneDX
         end
       end
 
-      def missing(name)
-        name.nil? || name.to_s.strip.empty?
+      def missing(str)
+        str.nil? || str.to_s.strip.empty?
       end
 
-      def exists_and_blank(group)
-        !group.nil? && group.to_s.strip.empty?
+      def exists_and_blank(str)
+        !str.nil? && str.to_s.strip.empty?
       end
     end
   end

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -21,30 +21,30 @@
 
 module CycloneDX
   module CocoaPods
-  # Represents a software component in the CycloneDX BOM specification
-  #
-  # A component is a self-contained unit of software that can be used as a building block
-  # in the architecture of a software system. Components can be of different types like
-  # libraries, frameworks, or applications.
-  #
-  # @attr_reader [String, nil] group The group/organization identifier of the component
-  # @attr_reader [String] name The name of the component
-  # @attr_reader [String] version The version string of the component
-  # @attr_reader [String] type The type of component (must be one of VALID_COMPONENT_TYPES)
-  # @attr_reader [String] bomref The unique reference ID for this component in the BOM
-  # @attr_reader [String, nil] build_system The build system information
-  # @attr_reader [String, nil] vcs The version control system information
-  #
-  # @example Creating a new component
-  #   component = Component.new(
-  #     name: "AFNetworking",
-  #     version: "4.0.1",
-  #     type: "library"
-  #   )
-  class Component
-    VALID_COMPONENT_TYPES = %w[application framework library container operating-system device firmware file].freeze
+    # Represents a software component in the CycloneDX BOM specification
+    #
+    # A component is a self-contained unit of software that can be used as a building block
+    # in the architecture of a software system. Components can be of different types like
+    # libraries, frameworks, or applications.
+    #
+    # @attr_reader [String, nil] group The group/organization identifier of the component
+    # @attr_reader [String] name The name of the component
+    # @attr_reader [String] version The version string of the component
+    # @attr_reader [String] type The type of component (must be one of VALID_COMPONENT_TYPES)
+    # @attr_reader [String] bomref The unique reference ID for this component in the BOM
+    # @attr_reader [String, nil] build_system The build system information
+    # @attr_reader [String, nil] vcs The version control system information
+    #
+    # @example Creating a new component
+    #   component = Component.new(
+    #     name: "AFNetworking",
+    #     version: "4.0.1",
+    #     type: "library"
+    #   )
+    class Component
+      VALID_COMPONENT_TYPES = %w[application framework library container operating-system device firmware file].freeze
 
-    attr_reader :group, :name, :version, :type, :bomref, :build_system, :vcs
+      attr_reader :group, :name, :version, :type, :bomref, :build_system, :vcs
 
       def initialize(name:, version:, type:, group: nil, build_system: nil, vcs: nil)
         raise ArgumentError, 'Group, if specified, must be non empty' if !group.nil? && group.to_s.strip.empty?

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -47,7 +47,7 @@ module CycloneDX
       attr_reader :group, :name, :version, :type, :bomref, :build_system, :vcs
 
       def initialize(name:, version:, type:, group: nil, build_system: nil, vcs: nil)
-        validate_attributes(name, version, type)
+        validate_attributes(name, version, type, group)
 
         @group = group
         @name = name
@@ -64,14 +64,22 @@ module CycloneDX
 
       private
 
-      def validate_attributes(name, version, type)
-        raise ArgumentError, 'Group, if specified, must be non empty' if !group.nil? && group.to_s.strip.empty?
-        raise ArgumentError, 'Name must be non empty' if name.nil? || name.to_s.strip.empty?
+      def validate_attributes(name, version, type, group)
+        raise ArgumentError, 'Group, if specified, must be non-empty' if exists_and_blank(group)
+        raise ArgumentError, 'Name must be non-empty' if missing(name)
 
-        Gem::Version.new(version) # To check that the version string is well formed
+        Gem::Version.new(version) # To check that the version string is well-formed
         unless VALID_COMPONENT_TYPES.include?(type)
           raise ArgumentError, "#{type} is not valid component type (#{VALID_COMPONENT_TYPES.join('|')})"
         end
+      end
+
+      def missing(name)
+        name.nil? || name.to_s.strip.empty?
+      end
+
+      def exists_and_blank(group)
+        !group.nil? && group.to_s.strip.empty?
       end
     end
   end

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -69,9 +69,9 @@ module CycloneDX
         raise ArgumentError, 'Name must be non-empty' if missing(name)
 
         Gem::Version.new(version) # To check that the version string is well-formed
-        unless VALID_COMPONENT_TYPES.include?(type)
-          raise ArgumentError, "#{type} is not valid component type (#{VALID_COMPONENT_TYPES.join('|')})"
-        end
+        return if VALID_COMPONENT_TYPES.include?(type)
+
+        raise ArgumentError, "#{type} is not valid component type (#{VALID_COMPONENT_TYPES.join('|')})"
       end
 
       def missing(str)

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -21,10 +21,30 @@
 
 module CycloneDX
   module CocoaPods
-    class Component
-      VALID_COMPONENT_TYPES = %w[application framework library container operating-system device firmware file].freeze
+  # Represents a software component in the CycloneDX BOM specification
+  #
+  # A component is a self-contained unit of software that can be used as a building block
+  # in the architecture of a software system. Components can be of different types like
+  # libraries, frameworks, or applications.
+  #
+  # @attr_reader [String, nil] group The group/organization identifier of the component
+  # @attr_reader [String] name The name of the component
+  # @attr_reader [String] version The version string of the component
+  # @attr_reader [String] type The type of component (must be one of VALID_COMPONENT_TYPES)
+  # @attr_reader [String] bomref The unique reference ID for this component in the BOM
+  # @attr_reader [String, nil] build_system The build system information
+  # @attr_reader [String, nil] vcs The version control system information
+  #
+  # @example Creating a new component
+  #   component = Component.new(
+  #     name: "AFNetworking",
+  #     version: "4.0.1",
+  #     type: "library"
+  #   )
+  class Component
+    VALID_COMPONENT_TYPES = %w[application framework library container operating-system device firmware file].freeze
 
-      attr_reader :group, :name, :version, :type, :bomref, :build_system, :vcs
+    attr_reader :group, :name, :version, :type, :bomref, :build_system, :vcs
 
       def initialize(name:, version:, type:, group: nil, build_system: nil, vcs: nil)
         raise ArgumentError, 'Group, if specified, must be non empty' if !group.nil? && group.to_s.strip.empty?

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -24,9 +24,9 @@ module CycloneDX
     class Component
       VALID_COMPONENT_TYPES = %w[application framework library container operating-system device firmware file].freeze
 
-      attr_reader :group, :name, :version, :type, :bomref, :buildSystem, :vcs
+      attr_reader :group, :name, :version, :type, :bomref, :build_system, :vcs
 
-      def initialize(name:, version:, type:, group: nil, buildSystem: nil, vcs: nil)
+      def initialize(name:, version:, type:, group: nil, build_system: nil, vcs: nil)
         raise ArgumentError, 'Group, if specified, must be non empty' if !group.nil? && group.to_s.strip.empty?
         raise ArgumentError, 'Name must be non empty' if name.nil? || name.to_s.strip.empty?
 
@@ -39,7 +39,7 @@ module CycloneDX
         @name = name
         @version = version
         @type = type
-        @buildSystem = buildSystem
+        @build_system = build_system
         @vcs = vcs
         @bomref = "#{name}@#{version}"
 

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -24,9 +24,9 @@ module CycloneDX
     class Component
       VALID_COMPONENT_TYPES = %w[application framework library container operating-system device firmware file].freeze
 
-      attr_reader :group, :name, :version, :type, :bomref
+      attr_reader :group, :name, :version, :type, :bomref, :buildSystem, :vcs
 
-      def initialize(name:, version:, type:, group: nil)
+      def initialize(name:, version:, type:, group: nil, buildSystem: nil, vcs: nil)
         raise ArgumentError, 'Group, if specified, must be non empty' if !group.nil? && group.to_s.strip.empty?
         raise ArgumentError, 'Name must be non empty' if name.nil? || name.to_s.strip.empty?
 
@@ -39,6 +39,8 @@ module CycloneDX
         @name = name
         @version = version
         @type = type
+        @buildSystem = buildSystem
+        @vcs = vcs
         @bomref = "#{name}@#{version}"
 
         return if group.nil?

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -47,13 +47,7 @@ module CycloneDX
       attr_reader :group, :name, :version, :type, :bomref, :build_system, :vcs
 
       def initialize(name:, version:, type:, group: nil, build_system: nil, vcs: nil)
-        raise ArgumentError, 'Group, if specified, must be non empty' if !group.nil? && group.to_s.strip.empty?
-        raise ArgumentError, 'Name must be non empty' if name.nil? || name.to_s.strip.empty?
-
-        Gem::Version.new(version) # To check that the version string is well formed
-        unless VALID_COMPONENT_TYPES.include?(type)
-          raise ArgumentError, "#{type} is not valid component type (#{VALID_COMPONENT_TYPES.join('|')})"
-        end
+        validate_attributes(name, version, type)
 
         @group = group
         @name = name
@@ -66,6 +60,18 @@ module CycloneDX
         return if group.nil?
 
         @bomref = "#{group}/#{@bomref}"
+      end
+
+      private
+
+      def validate_attributes(name, version, type)
+        raise ArgumentError, 'Group, if specified, must be non empty' if !group.nil? && group.to_s.strip.empty?
+        raise ArgumentError, 'Name must be non empty' if name.nil? || name.to_s.strip.empty?
+
+        Gem::Version.new(version) # To check that the version string is well formed
+        unless VALID_COMPONENT_TYPES.include?(type)
+          raise ArgumentError, "#{type} is not valid component type (#{VALID_COMPONENT_TYPES.join('|')})"
+        end
       end
     end
   end

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -290,6 +290,44 @@ RSpec.describe CycloneDX::CocoaPods::Component do
         expect(xml.at('/component')['bom-ref']).to eq('application-group/Application@1.3.5')
       end
     end
+
+    context 'with a vcs' do
+      let(:component) do
+        described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application', vcs: 'https://github.com/Alamofire/Alamofire.git')
+      end
+      let(:xml) do
+        Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
+      end
+
+      it_behaves_like 'component'
+
+      it 'should generate a proper group element' do
+        expect(xml.at('/component/group')).not_to be_nil
+        expect(xml.at('/component/group').text).to eq(component.group)
+        expect(xml.at('/component')['bom-ref']).to eq('application-group/Application@1.3.5')
+        expect(xml.at('/component/externalReferences/reference')['type']).to eq('vcs')
+        expect(xml.at('/component/externalReferences/reference/url').text).to eq(component.vcs)
+      end
+    end
+
+    context 'with a build system' do
+      let(:component) do
+        described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application', buildSystem: 'https://github.com/Alamofire/Alamofire/actions/runs/12012983790')
+      end
+      let(:xml) do
+        Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
+      end
+
+      it_behaves_like 'component'
+
+      it 'should generate a proper group element' do
+        expect(xml.at('/component/group')).not_to be_nil
+        expect(xml.at('/component/group').text).to eq(component.group)
+        expect(xml.at('/component')['bom-ref']).to eq('application-group/Application@1.3.5')
+        expect(xml.at('/component/externalReferences/reference')['type']).to eq('build-system')
+        expect(xml.at('/component/externalReferences/reference/url').text).to eq(component.buildSystem)
+      end
+    end
   end
 end
 

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -293,7 +293,8 @@ RSpec.describe CycloneDX::CocoaPods::Component do
 
     context 'with a vcs' do
       let(:component) do
-        described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application', vcs: 'https://github.com/Alamofire/Alamofire.git')
+        described_class.new(group: 'application-group', name: 'Application', version: '1.3.5',
+                            type: 'application', vcs: 'https://github.com/Alamofire/Alamofire.git')
       end
       let(:xml) do
         Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
@@ -312,7 +313,8 @@ RSpec.describe CycloneDX::CocoaPods::Component do
 
     context 'with a build system' do
       let(:component) do
-        described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application', buildSystem: 'https://github.com/Alamofire/Alamofire/actions/runs/12012983790')
+        described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application',
+                            build_system: 'https://github.com/Alamofire/Alamofire/actions/runs/12012983790')
       end
       let(:xml) do
         Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
@@ -325,7 +327,7 @@ RSpec.describe CycloneDX::CocoaPods::Component do
         expect(xml.at('/component/group').text).to eq(component.group)
         expect(xml.at('/component')['bom-ref']).to eq('application-group/Application@1.3.5')
         expect(xml.at('/component/externalReferences/reference')['type']).to eq('build-system')
-        expect(xml.at('/component/externalReferences/reference/url').text).to eq(component.buildSystem)
+        expect(xml.at('/component/externalReferences/reference/url').text).to eq(component.build_system)
       end
     end
   end

--- a/spec/cyclonedx/cocoapods/component_spec.rb
+++ b/spec/cyclonedx/cocoapods/component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CycloneDX::CocoaPods::Component do
         expect do
           described_class.new(group: '    ', name: name, version: version,
                               type: type)
-        end.to raise_error(ArgumentError, 'Group, if specified, must be non empty')
+        end.to raise_error(ArgumentError, 'Group, if specified, must be non-empty')
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       it 'should raise an error' do
         expect do
           described_class.new(name: nil, version: version, type: type)
-        end.to raise_error(ArgumentError, 'Name must be non empty')
+        end.to raise_error(ArgumentError, 'Name must be non-empty')
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe CycloneDX::CocoaPods::Component do
         expect do
           described_class.new(name: '   ', version: version,
                               type: type)
-        end.to raise_error(ArgumentError, 'Name must be non empty')
+        end.to raise_error(ArgumentError, 'Name must be non-empty')
       end
     end
 


### PR DESCRIPTION
Add options to add the build and version control systems to the `metadata/component/externalReferences`. These options are useful as you can specify the values using environment variables from most CI systems.