### PR TITLE
fix: use purl as bomref

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ OPTIONS
     -s, --shortened-strings length   Trim author, publisher, and purl to <length> characters; this may cause data loss but can improve compatibility with other systems
 
   Component Metadata
+  If a podspec file is present the name, version, and type do not need to be specified as they will be set automatically.
+
     -n, --name name                  (If specified version and type are also required) Name of the component for which the BOM is generated
     -v, --version version            Version of the component for which the BOM is generated
     -t, --type type                  Type of the component for which the BOM is generated (one of application|framework|library|container|operating-system|device|firmware|file)

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -183,6 +183,7 @@ module CycloneDX
               end
             end
           end
+          xml.purl bomref
         end
       end
     end

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -253,9 +253,9 @@ module CycloneDX
         raise OptionParser::InvalidArgument, "Component type must be 'library' when using a podspec" unless
           !podspec.nil? && options[:type] && options[:type] == 'library'
 
-        if !podspec.nil?
-          options[:type] = 'library'
-        end
+        return unless !podspec.nil?
+
+        options[:type] = 'library'
       end
 
       def validate_group_option(options, podspec)

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -233,30 +233,25 @@ module CycloneDX
       end
 
       def validate_options_match(options, podspec)
-        if !podspec.nil? && options[:name] && options[:name] != podspec.name
-          raise OptionParser::InvalidArgument,
-                "Component name '#{options[:name]}' does not match podspec name '#{podspec.name}'"
-        end
-        if !podspec.nil? && options[:version] && options[:version] != podspec.version.to_s
-          raise OptionParser::InvalidArgument,
-                "Component version '#{options[:version]}' does not match podspec version '#{podspec.version}'"
-        end
+        raise OptionParser::InvalidArgument,
+              "Component name '#{options[:name]}' does not match podspec name '#{podspec.name}'" unless
+          !podspec.nil? && options[:name] && options[:name] != podspec.name
+        raise OptionParser::InvalidArgument,
+              "Component version '#{options[:version]}' does not match podspec version '#{podspec.version}'" unless
+          !podspec.nil? && options[:version] && options[:version] != podspec.version.to_s
         options[:name] ||= podspec&.name
         options[:version] ||= podspec&.version&.to_s
       end
 
       def validate_type_option(options, podspec)
-        if options[:type] && options[:type] != 'library'
-          raise OptionParser::InvalidArgument, "Component type must be 'library' when using a podspec"
-        else
-          options[:type] = 'library'
-        end unless !podspec.nil?
+        raise OptionParser::InvalidArgument, "Component type must be 'library' when using a podspec" unless
+          !podspec.nil? && options[:type] && options[:type] != 'library'
+        options[:type] = 'library' unless !podspec.nil?
       end
 
       def validate_group_option(options, podspec)
-        if !podspec.nil? && options[:group]
-          raise OptionParser::InvalidArgument, 'Component group must not be specified when using a podspec'
-        end
+        raise OptionParser::InvalidArgument, 'Component group must not be specified when using a podspec' unless
+          !podspec.nil? && options[:group]
       end
 
       def setup_logger(verbose: true)

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -227,26 +227,35 @@ module CycloneDX
       end
 
       def ensure_options_match(options, podspec)
-        validate_options_match(options, podspec)
+        validate_name_option(options, podspec)
+        validate_version_option(options, podspec)
         validate_group_option(options, podspec)
         validate_type_option(options, podspec)
       end
 
-      def validate_options_match(options, podspec)
-        raise OptionParser::InvalidArgument,
-              "Component name '#{options[:name]}' does not match podspec name '#{podspec.name}'" unless
-          !podspec.nil? && options[:name] && options[:name] != podspec.name
-        raise OptionParser::InvalidArgument,
-              "Component version '#{options[:version]}' does not match podspec version '#{podspec.version}'" unless
-          !podspec.nil? && options[:version] && options[:version] != podspec.version.to_s
+      def validate_name_option(options, podspec)
+        unless !podspec.nil? && options[:name] && options[:name] != podspec.name
+          raise OptionParser::InvalidArgument,
+                "Component name '#{options[:name]}' does not match podspec name '#{podspec.name}'"
+        end
         options[:name] ||= podspec&.name
+      end
+
+      def validate_version_option(options, podspec)
+        unless !podspec.nil? && options[:version] && options[:version] != podspec.version.to_s
+          raise OptionParser::InvalidArgument,
+                "Component version '#{options[:version]}' does not match podspec version '#{podspec.version}'"
+        end
         options[:version] ||= podspec&.version&.to_s
       end
 
       def validate_type_option(options, podspec)
         raise OptionParser::InvalidArgument, "Component type must be 'library' when using a podspec" unless
           !podspec.nil? && options[:type] && options[:type] != 'library'
-        options[:type] = 'library' unless !podspec.nil?
+
+        if !podspec.nil?
+          options[:type] = 'library'
+        end
       end
 
       def validate_group_option(options, podspec)

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -253,14 +253,15 @@ module CycloneDX
         raise OptionParser::InvalidArgument, "Component type must be 'library' when using a podspec" unless
           !podspec.nil? && options[:type] && options[:type] == 'library'
 
-        return unless !podspec.nil?
+        return if podspec.nil?
 
         options[:type] = 'library'
       end
 
       def validate_group_option(options, podspec)
+        return if podspec.nil?
         raise OptionParser::InvalidArgument, 'Component group must not be specified when using a podspec' unless
-          !podspec.nil? && options[:group].nil?
+          options[:group].nil?
       end
 
       def setup_logger(verbose: true)

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -234,7 +234,7 @@ module CycloneDX
       end
 
       def validate_name_option(options, podspec)
-        unless !podspec.nil? && options[:name] && options[:name] != podspec.name
+        unless !podspec.nil? && options[:name] && options[:name] == podspec.name
           raise OptionParser::InvalidArgument,
                 "Component name '#{options[:name]}' does not match podspec name '#{podspec.name}'"
         end
@@ -242,7 +242,7 @@ module CycloneDX
       end
 
       def validate_version_option(options, podspec)
-        unless !podspec.nil? && options[:version] && options[:version] != podspec.version.to_s
+        unless !podspec.nil? && options[:version] && options[:version] == podspec.version.to_s
           raise OptionParser::InvalidArgument,
                 "Component version '#{options[:version]}' does not match podspec version '#{podspec.version}'"
         end
@@ -251,7 +251,7 @@ module CycloneDX
 
       def validate_type_option(options, podspec)
         raise OptionParser::InvalidArgument, "Component type must be 'library' when using a podspec" unless
-          !podspec.nil? && options[:type] && options[:type] != 'library'
+          !podspec.nil? && options[:type] && options[:type] == 'library'
 
         if !podspec.nil?
           options[:type] = 'library'
@@ -260,7 +260,7 @@ module CycloneDX
 
       def validate_group_option(options, podspec)
         raise OptionParser::InvalidArgument, 'Component group must not be specified when using a podspec' unless
-          !podspec.nil? && options[:group]
+          !podspec.nil? && options[:group].nil?
       end
 
       def setup_logger(verbose: true)

--- a/lib/cyclonedx/cocoapods/cli_runner.rb
+++ b/lib/cyclonedx/cocoapods/cli_runner.rb
@@ -255,7 +255,7 @@ module CycloneDX
 
         return if podspec.nil?
 
-        options[:type] = 'library'
+        options[:type] = 'cocoapods'
       end
 
       def validate_group_option(options, podspec)

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -47,22 +47,23 @@ module CycloneDX
       attr_reader :group, :name, :version, :type, :bomref, :build_system, :vcs
 
       def initialize(name:, version:, type:, group: nil, build_system: nil, vcs: nil)
-        validate_attributes(name, version, type, group)
+        # cocoapods is a special case to correctly build a purl
+        package_type = (type == 'cocoapods') ? 'cocoapods' : 'generic'
+        @type = type == 'cocoapods' ? 'library' : type
+
+        validate_attributes(name, version, @type, group)
 
         @group = group
         @name = name
         @version = version
-        @type = type
         @build_system = build_system
         @vcs = vcs
-        @bomref = build_purl(type, name, group, version)
-
+        @bomref = build_purl(package_type, name, group, version)
       end
 
       private
 
-      def build_purl(type, name, group, version)
-        package_type = type == 'library' ? 'cocoapods' : 'generic'
+      def build_purl(package_type, name, group, version)
         if group.nil?
           purl_name, subpath = parse_name(name)
         else

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -105,19 +105,6 @@ module CycloneDX
       def exists_and_blank(str)
         !str.nil? && str.to_s.strip.empty?
       end
-
-      def create_purl(name)
-        purls = name.split('/')
-        purl_name = CGI.escape(purls[0])
-        subpath = if purls.length > 1
-                    "##{name.split('/').drop(1).map do |component|
-                      CGI.escape(component)
-                    end.join('/')}"
-                  else
-                    ''
-                  end
-        [purl_name, subpath]
-      end
     end
   end
 end

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -100,7 +100,7 @@ module CycloneDX
                   else
                     ''
                   end
-        return purl_name, subpath
+        [purl_name, subpath]
       end
     end
   end

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -55,11 +55,29 @@ module CycloneDX
         @type = type
         @build_system = build_system
         @vcs = vcs
-        @bomref = "#{name}@#{version}"
+        @bomref = build_purl(name, group, version)
 
-        return if group.nil?
+      end
 
-        @bomref = "#{group}/#{@bomref}"
+      private
+
+      def build_purl(name, group, version)
+        if group.nil?
+          purls = name.split('/')
+          purl_name = CGI.escape(purls[0])
+          if purls.length > 1
+            subpath = "##{name.split('/').drop(1).map do |component|
+              CGI.escape(component)
+            end.join('/')}"
+          else
+            subpath = ''
+          end
+        else
+          # this seems wrong as cocoapods does not use groups?
+          purl_name = "#{CGI.escape(group)}/#{CGI.escape(name)}"
+          subpath = ''
+        end
+        "pkg:cocoapods/#{purl_name}@#{CGI.escape(version.to_s)}#{subpath}"
       end
 
       private

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -48,7 +48,7 @@ module CycloneDX
 
       def initialize(name:, version:, type:, group: nil, build_system: nil, vcs: nil)
         # cocoapods is a special case to correctly build a purl
-        package_type = (type == 'cocoapods') ? 'cocoapods' : 'generic'
+        package_type = type == 'cocoapods' ? 'cocoapods' : 'generic'
         @type = type == 'cocoapods' ? 'library' : type
 
         validate_attributes(name, version, @type, group)

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -66,7 +66,6 @@ module CycloneDX
         if group.nil?
           purl_name, subpath = parse_name(name)
         else
-          # this seems wrong as cocoapods does not use groups?
           purl_name = "#{CGI.escape(group)}/#{CGI.escape(name)}"
           subpath = ''
         end

--- a/lib/cyclonedx/cocoapods/component.rb
+++ b/lib/cyclonedx/cocoapods/component.rb
@@ -63,15 +63,7 @@ module CycloneDX
 
       def build_purl(name, group, version)
         if group.nil?
-          purls = name.split('/')
-          purl_name = CGI.escape(purls[0])
-          if purls.length > 1
-            subpath = "##{name.split('/').drop(1).map do |component|
-              CGI.escape(component)
-            end.join('/')}"
-          else
-            subpath = ''
-          end
+          purl_name, subpath = create_purl(name)
         else
           # this seems wrong as cocoapods does not use groups?
           purl_name = "#{CGI.escape(group)}/#{CGI.escape(name)}"
@@ -79,8 +71,6 @@ module CycloneDX
         end
         "pkg:cocoapods/#{purl_name}@#{CGI.escape(version.to_s)}#{subpath}"
       end
-
-      private
 
       def validate_attributes(name, version, type, group)
         raise ArgumentError, 'Group, if specified, must be non-empty' if exists_and_blank(group)
@@ -98,6 +88,19 @@ module CycloneDX
 
       def exists_and_blank(str)
         !str.nil? && str.to_s.strip.empty?
+      end
+
+      def create_purl(name)
+        purls = name.split('/')
+        purl_name = CGI.escape(purls[0])
+        subpath = if purls.length > 1
+                    "##{name.split('/').drop(1).map do |component|
+                      CGI.escape(component)
+                    end.join('/')}"
+                  else
+                    ''
+                  end
+        return purl_name, subpath
       end
     end
   end

--- a/lib/cyclonedx/cocoapods/podspec_analyzer.rb
+++ b/lib/cyclonedx/cocoapods/podspec_analyzer.rb
@@ -31,6 +31,18 @@ module CycloneDX
   module CocoaPods
     class PodspecParsingError < StandardError; end
 
+    # Analyzes CocoaPods podspec files to extract component information for CycloneDX BOM generation
+    #
+    # The PodspecAnalyzer is responsible for:
+    # - Validating and loading podspec files from a given path
+    # - Parsing podspec contents to extract pod metadata
+    # - Converting podspec source information into standardized Source objects
+    #
+    # @example
+    #   analyzer = PodspecAnalyzer.new(logger: Logger.new(STDOUT))
+    #   podspec = analyzer.ensure_podspec_is_present(path: '/path/to/project')
+    #   pod = analyzer.parse_podspec(podspec)
+    #
     class PodspecAnalyzer
       def initialize(logger:)
         @logger = logger
@@ -49,13 +61,12 @@ module CycloneDX
 
         @logger.debug "Parsing podspec from #{podspec.defined_in_file}"
 
-        pod = Pod.new(
+        Pod.new(
           name: podspec.name,
           version: podspec.version.to_s,
           source: source_from_podspec(podspec),
           checksum: nil
         )
-        pod
       end
 
       private
@@ -79,8 +90,6 @@ module CycloneDX
             type: determine_git_ref_type(podspec.source),
             label: determine_git_ref_label(podspec.source)
           )
-        else
-          nil
         end
       end
 
@@ -88,6 +97,7 @@ module CycloneDX
         return :tag if source[:tag]
         return :commit if source[:commit]
         return :branch if source[:branch]
+
         nil
       end
 

--- a/lib/cyclonedx/cocoapods/podspec_analyzer.rb
+++ b/lib/cyclonedx/cocoapods/podspec_analyzer.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#
+# This file is part of CycloneDX CocoaPods
+#
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+#
+
+require 'cocoapods'
+require 'cocoapods-core'
+require 'logger'
+
+require_relative 'pod'
+require_relative 'pod_attributes'
+require_relative 'source'
+
+module CycloneDX
+  module CocoaPods
+    class PodspecParsingError < StandardError; end
+
+    class PodspecAnalyzer
+      def initialize(logger:)
+        @logger = logger
+      end
+
+      def ensure_podspec_is_present(options)
+        project_dir = Pathname.new(options[:path] || Dir.pwd)
+        validate_options(project_dir, options)
+        initialize_cocoapods_config(project_dir)
+
+        options[:podspec_path].nil? ? nil : ::Pod::Specification.from_file(options[:podspec_path])
+      end
+
+      def parse_podspec(podspec)
+        return nil if podspec.nil?
+
+        @logger.debug "Parsing podspec from #{podspec.defined_in_file}"
+
+        pod = Pod.new(
+          name: podspec.name,
+          version: podspec.version.to_s,
+          source: source_from_podspec(podspec),
+          checksum: nil
+        )
+        pod
+      end
+
+      private
+
+      def validate_options(project_dir, options)
+        raise PodspecParsingError, "#{options[:path]} is not a valid directory." unless File.directory?(project_dir)
+
+        podspec_files = Dir.glob("#{project_dir}/*.podspec{.json,}")
+        options[:podspec_path] = podspec_files.first unless podspec_files.empty?
+      end
+
+      def initialize_cocoapods_config(project_dir)
+        ::Pod::Config.instance = nil
+        ::Pod::Config.instance.installation_root = project_dir
+      end
+
+      def source_from_podspec(podspec)
+        if podspec.source[:git]
+          Source::GitRepository.new(
+            url: podspec.source[:git],
+            type: determine_git_ref_type(podspec.source),
+            label: determine_git_ref_label(podspec.source)
+          )
+        else
+          nil
+        end
+      end
+
+      def determine_git_ref_type(source)
+        return :tag if source[:tag]
+        return :commit if source[:commit]
+        return :branch if source[:branch]
+        nil
+      end
+
+      def determine_git_ref_label(source)
+        source[:tag] || source[:commit] || source[:branch]
+      end
+    end
+  end
+end

--- a/lib/cyclonedx/cocoapods/podspec_analyzer.rb
+++ b/lib/cyclonedx/cocoapods/podspec_analyzer.rb
@@ -84,13 +84,13 @@ module CycloneDX
       end
 
       def source_from_podspec(podspec)
-        if podspec.source[:git]
-          Source::GitRepository.new(
-            url: podspec.source[:git],
-            type: determine_git_ref_type(podspec.source),
-            label: determine_git_ref_label(podspec.source)
-          )
-        end
+        return unless podspec.source[:git]
+
+        Source::GitRepository.new(
+          url: podspec.source[:git],
+          type: determine_git_ref_type(podspec.source),
+          label: determine_git_ref_label(podspec.source)
+        )
       end
 
       def determine_git_ref_type(source)

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -286,8 +286,8 @@ RSpec.describe CycloneDX::CocoaPods::Component do
 
       it 'should not generate any group element' do
         expect(xml.at('/component/group')).to be_nil
-        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/Application@1.3.5')
-        expect(xml.at('/component/purl').text).to eq('pkg:cocoapods/Application@1.3.5')
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:generic/Application@1.3.5')
+        expect(xml.at('/component/purl').text).to eq('pkg:generic/Application@1.3.5')
       end
     end
 
@@ -323,8 +323,8 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       it 'should generate a proper group element' do
         expect(xml.at('/component/group')).not_to be_nil
         expect(xml.at('/component/group').text).to eq(component.group)
-        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/application-group/Application@1.3.5')
-        expect(xml.at('/component/purl').text).to eq('pkg:cocoapods/application-group/Application@1.3.5')
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:generic/application-group/Application@1.3.5')
+        expect(xml.at('/component/purl').text).to eq('pkg:generic/application-group/Application@1.3.5')
       end
     end
 

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -271,7 +271,8 @@ RSpec.describe CycloneDX::CocoaPods::Component do
 
       it 'should not generate any group element' do
         expect(xml.at('/component/group')).to be_nil
-        expect(xml.at('/component')['bom-ref']).to eq('Application@1.3.5')
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/Application@1.3.5')
+        expect(xml.at('/component/purl').text).to eq('pkg:cocoapods/Application@1.3.5')
       end
     end
 
@@ -288,7 +289,8 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       it 'should generate a proper group element' do
         expect(xml.at('/component/group')).not_to be_nil
         expect(xml.at('/component/group').text).to eq(component.group)
-        expect(xml.at('/component')['bom-ref']).to eq('application-group/Application@1.3.5')
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/application-group/Application@1.3.5')
+        expect(xml.at('/component/purl').text).to eq('pkg:cocoapods/application-group/Application@1.3.5')
       end
     end
 

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -261,8 +261,23 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       end
     end
 
-    context 'without a group' do
+    context 'without a group and type application' do
       let(:component) { described_class.new(name: 'Application', version: '1.3.5', type: 'application') }
+      let(:xml) do
+        Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
+      end
+
+      it_behaves_like 'component'
+
+      it 'should not generate any group element' do
+        expect(xml.at('/component/group')).to be_nil
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:generic/Application@1.3.5')
+        expect(xml.at('/component/purl').text).to eq('pkg:generic/Application@1.3.5')
+      end
+    end
+
+    context 'without a group and type library' do
+      let(:component) { described_class.new(name: 'Application', version: '1.3.5', type: 'library') }
       let(:xml) do
         Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
       end
@@ -276,9 +291,28 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       end
     end
 
-    context 'with a group' do
+    context 'with a group and type Application' do
       let(:component) do
         described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application')
+      end
+      let(:xml) do
+        Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
+      end
+
+      it_behaves_like 'component'
+
+      it 'should generate a proper group element' do
+        expect(xml.at('/component/group')).not_to be_nil
+        expect(xml.at('/component/group').text).to eq(component.group)
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:generic/application-group/Application@1.3.5')
+        expect(xml.at('/component/purl').text).to eq('pkg:generic/application-group/Application@1.3.5')
+      end
+    end
+
+    ## this test is just for completeness, the group is not used for libraries
+    context 'with a group and type library' do
+      let(:component) do
+        described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'library')
       end
       let(:xml) do
         Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
@@ -305,10 +339,10 @@ RSpec.describe CycloneDX::CocoaPods::Component do
 
       it_behaves_like 'component'
 
-      it 'should generate a proper group element' do
+      it 'should generate a proper external references for vcs' do
         expect(xml.at('/component/group')).not_to be_nil
         expect(xml.at('/component/group').text).to eq(component.group)
-        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/application-group/Application@1.3.5')
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:generic/application-group/Application@1.3.5')
         expect(xml.at('/component/externalReferences/reference')['type']).to eq('vcs')
         expect(xml.at('/component/externalReferences/reference/url').text).to eq(component.vcs)
       end
@@ -325,10 +359,10 @@ RSpec.describe CycloneDX::CocoaPods::Component do
 
       it_behaves_like 'component'
 
-      it 'should generate a proper group element' do
+      it 'should generate a proper external reference element for build-systems' do
         expect(xml.at('/component/group')).not_to be_nil
         expect(xml.at('/component/group').text).to eq(component.group)
-        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/application-group/Application@1.3.5')
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:generic/application-group/Application@1.3.5')
         expect(xml.at('/component/externalReferences/reference')['type']).to eq('build-system')
         expect(xml.at('/component/externalReferences/reference/url').text).to eq(component.build_system)
       end

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -291,6 +291,21 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       end
     end
 
+    context 'without type cocoapods - a special case' do
+      let(:component) { described_class.new(name: 'SampleProject', version: '1.0.0', type: 'cocoapods') }
+      let(:xml) do
+        Nokogiri::XML(Nokogiri::XML::Builder.new(encoding: 'UTF-8') { |xml| component.add_to_bom(xml) }.to_xml)
+      end
+
+      it_behaves_like 'component'
+
+      it 'should not generate any group element' do
+        expect(xml.at('/component/group')).to be_nil
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/SampleProject@1.0.0')
+        expect(xml.at('/component/purl').text).to eq('pkg:cocoapods/SampleProject@1.0.0')
+      end
+    end
+
     context 'with a group and type Application' do
       let(:component) do
         described_class.new(group: 'application-group', name: 'Application', version: '1.3.5', type: 'application')

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       it 'should generate a proper group element' do
         expect(xml.at('/component/group')).not_to be_nil
         expect(xml.at('/component/group').text).to eq(component.group)
-        expect(xml.at('/component')['bom-ref']).to eq('application-group/Application@1.3.5')
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/application-group/Application@1.3.5')
         expect(xml.at('/component/externalReferences/reference')['type']).to eq('vcs')
         expect(xml.at('/component/externalReferences/reference/url').text).to eq(component.vcs)
       end
@@ -328,7 +328,7 @@ RSpec.describe CycloneDX::CocoaPods::Component do
       it 'should generate a proper group element' do
         expect(xml.at('/component/group')).not_to be_nil
         expect(xml.at('/component/group').text).to eq(component.group)
-        expect(xml.at('/component')['bom-ref']).to eq('application-group/Application@1.3.5')
+        expect(xml.at('/component')['bom-ref']).to eq('pkg:cocoapods/application-group/Application@1.3.5')
         expect(xml.at('/component/externalReferences/reference')['type']).to eq('build-system')
         expect(xml.at('/component/externalReferences/reference/url').text).to eq(component.build_system)
       end

--- a/spec/cyclonedx/cocoapods/podspec_analyzer_spec.rb
+++ b/spec/cyclonedx/cocoapods/podspec_analyzer_spec.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+#
+# This file is part of CycloneDX CocoaPods
+#
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+#
+
 require 'cyclonedx/cocoapods/podspec_analyzer'
 require 'rspec'
 
@@ -27,18 +46,6 @@ RSpec.describe CycloneDX::CocoaPods::PodspecAnalyzer do
                         'bad_path_that_does_not_exist is not a valid directory.')
     end
 
-    it 'with SimplePod fixture should succeed' do
-      analyzer = CycloneDX::CocoaPods::PodspecAnalyzer.new(logger: @logger)
-
-      options = {
-        path: fixtures + 'SimplePod/',
-        podspec_path: fixtures + simple_pod
-      }
-      podspecs = analyzer.ensure_podspec_is_present(options)
-      expect(podspecs).not_to be_nil
-      expect(podspecs.length).to eq(1)
-    end
-
     it 'with EmptyPodfile fixture should return nil when no podspec exists' do
       analyzer = CycloneDX::CocoaPods::PodspecAnalyzer.new(logger: @logger)
 
@@ -46,7 +53,7 @@ RSpec.describe CycloneDX::CocoaPods::PodspecAnalyzer do
         path: fixtures + 'EmptyPodfile/'
       }
       podspecs = analyzer.ensure_podspec_is_present(options)
-      expect(podspecs.first).to be_nil
+      expect(podspecs).to be_nil
     end
   end
 
@@ -59,7 +66,7 @@ RSpec.describe CycloneDX::CocoaPods::PodspecAnalyzer do
         podspec_path: fixtures + simple_pod
       }
       podspecs = analyzer.ensure_podspec_is_present(options)
-      pod = analyzer.parse_podspec(podspecs.first)
+      pod = analyzer.parse_podspec(podspecs)
 
       expect(pod.name).to eq('SampleProject')
       expect(pod.version).to eq('1.0.0')
@@ -77,7 +84,7 @@ RSpec.describe CycloneDX::CocoaPods::PodspecAnalyzer do
         podspec_path: fixtures + simple_pod
       }
       podspecs = analyzer.ensure_podspec_is_present(options)
-      pod = analyzer.parse_podspec(podspecs.first)
+      pod = analyzer.parse_podspec(podspecs)
 
       expect(pod.source.type).to eq(:tag)
       expect(pod.source.label).not_to be_nil

--- a/spec/cyclonedx/cocoapods/podspec_analyzer_spec.rb
+++ b/spec/cyclonedx/cocoapods/podspec_analyzer_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'cyclonedx/cocoapods/podspec_analyzer'
+require 'rspec'
+
+RSpec.describe CycloneDX::CocoaPods::PodspecAnalyzer do
+  let(:fixtures) { Pathname.new(File.expand_path('../../fixtures', __dir__)) }
+  let(:simple_pod) { 'SimplePod/SimplePod.podspec' }
+
+  Pod::Config.instance.installation_root = "#{File.expand_path('../../fixtures', __dir__)}/"
+
+  before(:each) do
+    @log = StringIO.new
+    @logger = Logger.new(@log)
+  end
+
+  context 'Calling ensure_podspec_is_present' do
+    it 'with bad path should raise an error' do
+      analyzer = CycloneDX::CocoaPods::PodspecAnalyzer.new(logger: @logger)
+
+      options = {
+        path: 'bad_path_that_does_not_exist'
+      }
+      expect do
+        analyzer.ensure_podspec_is_present(options)
+      end.to raise_error(CycloneDX::CocoaPods::PodspecParsingError,
+                        'bad_path_that_does_not_exist is not a valid directory.')
+    end
+
+    it 'with SimplePod fixture should succeed' do
+      analyzer = CycloneDX::CocoaPods::PodspecAnalyzer.new(logger: @logger)
+
+      options = {
+        path: fixtures + 'SimplePod/',
+        podspec_path: fixtures + simple_pod
+      }
+      podspecs = analyzer.ensure_podspec_is_present(options)
+      expect(podspecs).not_to be_nil
+      expect(podspecs.length).to eq(1)
+    end
+
+    it 'with EmptyPodfile fixture should return nil when no podspec exists' do
+      analyzer = CycloneDX::CocoaPods::PodspecAnalyzer.new(logger: @logger)
+
+      options = {
+        path: fixtures + 'EmptyPodfile/'
+      }
+      podspecs = analyzer.ensure_podspec_is_present(options)
+      expect(podspecs.first).to be_nil
+    end
+  end
+
+  context 'parsing podspec' do
+    it 'should parse SimplePod podspec correctly' do
+      analyzer = CycloneDX::CocoaPods::PodspecAnalyzer.new(logger: @logger)
+
+      options = {
+        path: fixtures + 'SimplePod/',
+        podspec_path: fixtures + simple_pod
+      }
+      podspecs = analyzer.ensure_podspec_is_present(options)
+      pod = analyzer.parse_podspec(podspecs.first)
+
+      expect(pod.name).to eq('SampleProject')
+      expect(pod.version).to eq('1.0.0')
+      expect(pod.source).not_to be_nil
+      expect(pod.source.url).to include('github.com')
+    end
+  end
+
+  context 'parsing git source information' do
+    it 'should handle git repository with tag' do
+      analyzer = CycloneDX::CocoaPods::PodspecAnalyzer.new(logger: @logger)
+
+      options = {
+        path: fixtures + 'SimplePod/',
+        podspec_path: fixtures + simple_pod
+      }
+      podspecs = analyzer.ensure_podspec_is_present(options)
+      pod = analyzer.parse_podspec(podspecs.first)
+
+      expect(pod.source.type).to eq(:tag)
+      expect(pod.source.label).not_to be_nil
+    end
+  end
+end

--- a/spec/cyclonedx/cocoapods/podspec_analyzer_spec.rb
+++ b/spec/cyclonedx/cocoapods/podspec_analyzer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CycloneDX::CocoaPods::PodspecAnalyzer do
       expect do
         analyzer.ensure_podspec_is_present(options)
       end.to raise_error(CycloneDX::CocoaPods::PodspecParsingError,
-                        'bad_path_that_does_not_exist is not a valid directory.')
+                         'bad_path_that_does_not_exist is not a valid directory.')
     end
 
     it 'with EmptyPodfile fixture should return nil when no podspec exists' do

--- a/spec/fixtures/SimplePod/SampleProject.podspec
+++ b/spec/fixtures/SimplePod/SampleProject.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |spec|
+  spec.name         = "SampleProject"
+  spec.version      = "1.0.0"
+  spec.summary      = "Sample summary."
+  spec.description  = "Sample description."
+
+  spec.homepage     = "https://github.com/CycloneDX/cyclonedx-cocoapods"
+  spec.license      = "Apache-2.0"
+  spec.author       = { "CycloneDX SBOM Standard" => "email@address.com" }
+  spec.source       = { :git => "https://github.com/CycloneDX/cyclonedx-cocoapods.git", :tag => "#{spec.version}" }
+end


### PR DESCRIPTION
For the metadata component it would be great if we had a purl. As such, if we just make the bomref a purl we can use the value for both the bomref and the purl.