### PR TITLE
JSON format outputs the bom file version as an integer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1]
+
+### Fixed
+- Fixed JSON output to use an integer for the bom file version number. ([Issue #89](https://github.com/CycloneDX/cyclonedx-cocoapods/issues/89)) [@macblazer](https://github.com/macblazer).
+
 ## [2.0.0]
 
 ### Added

--- a/example_bom.json
+++ b/example_bom.json
@@ -3,7 +3,7 @@
     "bomFormat": "CycloneDX",
     "specVersion": "1.6",
     "serialNumber": "urn:uuid:b57875d9-a259-4c91-b04b-1e8894898089",
-    "version": "1",
+    "version": 1,
     "metadata":
     {
         "timestamp": "2025-01-07T03:54:06Z",

--- a/lib/cyclonedx/cocoapods/bom_builder.rb
+++ b/lib/cyclonedx/cocoapods/bom_builder.rb
@@ -403,7 +403,7 @@ module CycloneDX
           bomFormat: 'CycloneDX',
           specVersion: '1.6',
           serialNumber: "urn:uuid:#{SecureRandom.uuid}",
-          version: version.to_s,
+          version: version.to_i,
           metadata: generate_json_metadata,
           components: generate_json_components(trim_strings_length),
           dependencies: generate_json_dependencies
@@ -440,6 +440,7 @@ module CycloneDX
           }
         end
       end
+
       def bom_components(xml, pods, manifest_path, trim_strings_length)
         xml.components do
           pods.each do |pod|
@@ -468,6 +469,7 @@ module CycloneDX
           manufacturer&.add_to_bom(xml)
         end
       end
+
       def bom_tools(xml)
         xml.tools do
           xml.components do

--- a/lib/cyclonedx/cocoapods/version.rb
+++ b/lib/cyclonedx/cocoapods/version.rb
@@ -21,6 +21,6 @@
 
 module CycloneDX
   module CocoaPods
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end

--- a/spec/cyclonedx/cocoapods/bom_builder_spec.rb
+++ b/spec/cyclonedx/cocoapods/bom_builder_spec.rb
@@ -1353,7 +1353,7 @@ RSpec.describe CycloneDX::CocoaPods::BOMBuilder do
     it 'should generate proper root level attributes' do
       expect(bom_json[:bomFormat]).to eq('CycloneDX')
       expect(bom_json[:specVersion]).to eq('1.6')
-      expect(bom_json[:version]).to eq(version.to_s)
+      expect(bom_json[:version]).to eq(version.to_i)
       expect(bom_json[:serialNumber]).to match(/urn:uuid:.*/)
     end
 


### PR DESCRIPTION
This follows the CycloneDX JSON Schema for the file version number.  Fixes #89.